### PR TITLE
Add new shortcode attribute to limit no. of items shown

### DIFF
--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -38,7 +38,7 @@ class WeDocs_Shortcode_Handler {
             'col'     => '2',
             'include' => 'any',
             'exclude' => '',
-	        'items' => -1,
+            'items'   => -1,
             'more'    => __( 'View Details', 'wedocs' )
         );
 

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -38,6 +38,7 @@ class WeDocs_Shortcode_Handler {
             'col'     => '2',
             'include' => 'any',
             'exclude' => '',
+	        'items' => -1,
             'more'    => __( 'View Details', 'wedocs' )
         );
 
@@ -64,11 +65,12 @@ class WeDocs_Shortcode_Handler {
         if ( $parent_docs ) {
             foreach ($parent_docs as $root) {
                 $sections = get_children( array(
-                    'post_parent' => $root->ID,
-                    'post_type'   => 'docs',
-                    'post_status' => 'publish',
-                    'orderby'     => 'menu_order',
-                    'order'       => 'ASC'
+                    'post_parent'    => $root->ID,
+                    'post_type'      => 'docs',
+                    'post_status'    => 'publish',
+                    'orderby'        => 'menu_order',
+                    'order'          => 'ASC',
+                    'posts_per_page' => (int) $args['items'],
                 ) );
 
                 $arranged[] = array(

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -38,7 +38,7 @@ class WeDocs_Shortcode_Handler {
             'col'     => '2',
             'include' => 'any',
             'exclude' => '',
-            'items'   => -1,
+            'items'   => 10,
             'more'    => __( 'View Details', 'wedocs' )
         );
 


### PR DESCRIPTION
Having one attribute to limit no. of items shown under a section is a good idea. Because if one section has 10 docs and another section has 3, that doesn't look good (http://www.clipular.com/c/4600533885911040.png?k=SLjoisnTJ2GYw0gHKpN7z3pdmtU). If we can limit maximum items shown to 3, the UI wise, that will look good.