### PR TITLE
Show child docs posts in default

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -118,7 +118,7 @@
   width: auto;
 }
 .wedocs-row-actions {
-  visibility: hidden;
+  visibility: visible;
   color: #999;
 }
 .wedocs-row-actions a {

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -141,7 +141,7 @@
 }
 
 .wedocs-row-actions {
-    visibility: hidden;
+    visibility: visible;
     color: #999;
 
     a {

--- a/includes/admin/template-vue.php
+++ b/includes/admin/template-vue.php
@@ -34,7 +34,7 @@
                             </span>
                         </span>
 
-                        <ul class="articles collapsed connectedSortable" v-if="section.child" v-sortable>
+                        <ul class="articles connectedSortable" v-if="section.child" v-sortable>
                             <li class="article" v-for="(article, index) in section.child" :data-id="article.post.id">
                                 <a v-if="article.post.caps.edit" target="_blank" :href="editurl + article.post.id">{{ article.post.title }}<span v-if="article.post.status != 'publish'" class="doc-status">{{ article.post.status }}</span></a>
                                 <span v-else>{{ article.post.title }}</span>


### PR DESCRIPTION
Thank you for creating a nice plugin, love this.
There's a few of my suggestions on the admin side:
- It's better to show child docs in default
- And also it's good those icons for action are visible initially.

![aug-05-2018 20-03-19](https://user-images.githubusercontent.com/2969635/43685350-5e70a6de-98ec-11e8-84e5-7820b6826ff5.gif)
