### PR TITLE
Only enqueue css/js when the current page loads WeDocs via the shortcode

### DIFF
--- a/wedocs.php
+++ b/wedocs.php
@@ -217,6 +217,11 @@ class WeDocs {
      * @uses wp_enqueue_style
      */
     public function enqueue_scripts() {
+        global $post;
+
+        if (!is_a($post, 'WP_Post') || !has_shortcode($post->post_content, 'wedocs')) {
+            return;
+        }
 
         /**
          * All styles goes here


### PR DESCRIPTION
All required CSS and JavaScript files should only get enqueued when the current page loads an instance of WeDocs. The changes in this pull request ensures that file-requests for unnecessary resources are avoided by checking if the content of the current page contains the wedocs-shortcode.