### PR TITLE
Fix search API - add \ before WP_Query

### DIFF
--- a/includes/API/API.php
+++ b/includes/API/API.php
@@ -261,7 +261,7 @@ class API extends \WP_REST_Controller {
             }
         }
 
-        $query  = new WP_Query( $args );
+        $query  = new \WP_Query( $args );
         $docs   = $query->get_posts();
         $result = [];
 
@@ -277,7 +277,7 @@ class API extends \WP_REST_Controller {
             // Out-of-bounds, run the query again without LIMIT for total count.
             unset( $args['paged'] );
 
-            $count_query = new WP_Query();
+            $count_query = new \WP_Query();
             $count_query->query( $args );
             $total_posts = $count_query->found_posts;
         }


### PR DESCRIPTION
Fixing 500 error when requesting /wp-json/wp/v2/docs/search?query=test