### PR TITLE
Remove default value from required parameter

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -111,7 +111,7 @@ class Ajax {
      *
      * @return void
      */
-    public function remove_child_docs( $parent_id = 0, $force_delete ) {
+    public function remove_child_docs( $parent_id, $force_delete ) {
         $childrens = get_children( [ 'post_parent' => $parent_id ] );
 
         if ( $childrens ) {


### PR DESCRIPTION
This fixes a deprecation notice in PHP 8.0+:

> PHP Deprecated:  Required parameter $force_delete follows optional parameter $parent_id in wp-content/plugins/wedocs/includes/Ajax.php on line 114

Because `$force_delete` doesn't have a default value, that effectively makes `$parent_id` required as well.