### PR TITLE
options panel appearance on click instead of hover and popup modal design fix

### DIFF
--- a/src/components/DocActions.js
+++ b/src/components/DocActions.js
@@ -47,8 +47,8 @@ const DocActions = ( { doc, type, section, sections, setShowArticles } ) => {
     <Fragment>
       <div
         className="documentation-ellipsis-actions relative"
-        onMouseEnter={ () => setShowActions( true ) }
         onMouseLeave={ () => setShowActions( false ) }
+        onClick={()=>setShowActions(!showActions)}
       >
         <span
           className="dashicons dashicons-ellipsis d-block cursor-pointer text-sm rotate-90 text-gray-500"

--- a/src/components/DocListing/SectionArticles.js
+++ b/src/components/DocListing/SectionArticles.js
@@ -232,7 +232,7 @@ const SectionArticles = ( { article, articles, isAdmin, section, sections, searc
                 </div>
               </div>
               <div className="flex items-center gap-5 flex-shrink-0 mt-4 sm:mt-0 sm:ml-5">
-                <div className="flex items-center gap-0">
+                <div className="flex items-center gap-2">
                   { /* Render admin restriction icon. */ }
                   { wp?.hooks?.applyFilters(
                     'wedocs_article_privacy_action',

--- a/src/components/ProPreviews/common/UpgradePopup.js
+++ b/src/components/ProPreviews/common/UpgradePopup.js
@@ -51,7 +51,7 @@ const UpgradePopup = ({ children }) => {
             <div className='fixed inset-0 bg-black bg-opacity-25' />
           </Transition.Child>
 
-          <div className='fixed inset-0 overflow-y-auto'>
+          <div className='fixed inset-0 overflow-y-auto z-[99999]'>
             <div className='flex min-h-full items-center justify-center p-4 text-center'>
               <Transition.Child
                 as={ Fragment }


### PR DESCRIPTION
…ign fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Changed the action menu in documents to open and close with a click instead of on hover, making it easier to control visibility.
  * Improved the visibility of the upgrade popup by ensuring it always appears above all other page elements.
  * Increased spacing between admin restriction icons for better visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->