### PR TITLE
fix: Pro preview features showing when Pro plugin is active

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,11 +19,13 @@ const App = () => {
     { path: 'settings', component: SettingsPage },
     { path: 'section/:id', component: ListingPage },
     { path: 'migrate', component: Migrate },
-    { path: 'permission_settings', component: PermissionSettingsDemo },
-    { path: '*', component: NotFound },
+    // permission_settings route removed - Pro handles this via manager/:id
   ];
 
   routes = wp.hooks.applyFilters('wedocs_register_menu_routes', routes);
+  
+  // Add wildcard NotFound route LAST so it doesn't catch Pro routes
+  routes.push({ path: '*', component: NotFound });
   const router = createHashRouter(
     createRoutesFromElements(
       <>

--- a/src/components/PermissionSettingsDemo/PrivacySettings.js
+++ b/src/components/PermissionSettingsDemo/PrivacySettings.js
@@ -4,6 +4,8 @@ import Badge from '../ProPreviews/common/Badge';
 import UpgradePopup from '../ProPreviews/common/UpgradePopup';
 
 const PrivacySettings = ( ) => {
+ 	// Check if Pro is loaded dynamically
+	const isProLoaded = wp.hooks.applyFilters('wedocs_pro_loaded', false);
 	
 	return (
 		<div className="privacy-settings mt-8">
@@ -19,12 +21,10 @@ const PrivacySettings = ( ) => {
 						<input
 							id="public"
 							type="radio"
-							name="publish"
-							
-							 defaultChecked={ true }
-							className=
-								 'checked:!border-transparent checked:!bg-indigo-600 !mt-[.2rem] before:!bg-white before:!w-1.5 before:!h-1.5 before:!mt-1 before:!ml-1 place-content-center'
-							
+							name="privacy"
+							value="public"
+							defaultChecked={ true }
+							className='checked:!border-transparent checked:!bg-indigo-600 !mt-[.2rem] before:!bg-white before:!w-1.5 before:!h-1.5 before:!mt-1 before:!ml-1 place-content-center'
 						/>
 						<div className="ml-2 text-sm">
 							<label
@@ -42,19 +42,29 @@ const PrivacySettings = ( ) => {
 						</div>
 					</div>
 					<div className="field flex">
-						<UpgradePopup>
-	<input
-							id="privacy"
-							name="private"
-							type="radio"
-							className='!bg-transparent !border-[#8c8f94]
-							 !mt-[.2rem] before:!bg-white before:!w-1.5 before:!h-1.5 before:!mt-1 before:!ml-1 place-content-center'
-						/>
-						</UpgradePopup>
+						{isProLoaded ? (
+							<input
+								id="private"
+								name="privacy"
+								type="radio"
+								value="private"
+								className='checked:!border-transparent checked:!bg-indigo-600 !mt-[.2rem] before:!bg-white before:!w-1.5 before:!h-1.5 before:!mt-1 before:!ml-1 place-content-center'
+							/>
+						) : (
+							<UpgradePopup>
+								<input
+									id="private"
+									name="privacy"
+									type="radio"
+									value="private"
+									className='!bg-transparent !border-[#8c8f94] !mt-[.2rem] before:!bg-white before:!w-1.5 before:!h-1.5 before:!mt-1 before:!ml-1 place-content-center'
+								/>
+							</UpgradePopup>
+						)}
 					
 						<div className="ml-2 text-sm">
 							<label
-								htmlFor="privacy"
+								htmlFor="private"
 								className="font-medium text-gray-700 relative"
 							>
 								{ __( 'Private', 'wedocs' ) }
@@ -64,7 +74,9 @@ const PrivacySettings = ( ) => {
 										'wedocs'
 									) }
 								</p>
-								<Badge position='absolute' top="-5px" left="45px" heading="Permission Management is a Premium Feature" description="To see who contributed to the documents, you must upgrade to the pro edition."/>
+								{!isProLoaded && (
+									<Badge position='absolute' top="-5px" left="45px" heading="Permission Management is a Premium Feature" description="To see who contributed to the documents, you must upgrade to the pro edition."/>
+								)}
 							</label>
 						</div>
 					</div>

--- a/src/components/ProPreviews/index.js
+++ b/src/components/ProPreviews/index.js
@@ -221,11 +221,12 @@ wp.hooks.addFilter(
                     { userIsAdmin() && (
                         <>
                             { type === 'doc' && (
-                <a href={`${weDocsAdminVars.weDocsUrl}permission_settings`} className="group flex items-center py-2 px-4 text-sm font-medium text-gray-700 hover:bg-indigo-700 hover:text-white !shadow-none">
-                  <span>{ __( 'Permission Management', 'wedocs' ) }</span>
-                  <span className={ `crown cursor-pointer relative text-white text-[10px] py-[3px] px-[5px] leading-none ml-2.5` }>
+                <UpgradePopup>
+                  <span className="group flex items-center py-2 px-4 text-sm font-medium text-gray-700 hover:bg-indigo-700 hover:text-white !shadow-none cursor-pointer">
+                    <span>{ __( 'Permission Management', 'wedocs' ) }</span>
+                    <Badge classes="opacity-0 group-hover:opacity-100 transition-opacity ml-2"/>
                   </span>
-                </a>
+                </UpgradePopup>
                             ) }
                             { type === 'article' && (
                               
@@ -270,4 +271,27 @@ wp.hooks.addFilter(
         return <Contributors />;
     },
     5
+);
+
+wp.hooks.addFilter(
+	'wedocs_article_restriction_menu',
+	'wedocs_free_article_restriction_menu_preview',
+	function ( menu ) {
+		// Check if Pro is loaded dynamically
+		const isProLoaded = wp.hooks.applyFilters('wedocs_pro_loaded', false);
+		if (isProLoaded) return menu;
+		
+		// Return PRO preview menu when Pro is not loaded
+		return (
+			<UpgradePopup>
+				<a
+					href="#"
+					className="group flex items-center py-2 px-4 text-sm font-medium text-gray-700 hover:bg-indigo-700 hover:text-white !shadow-none"
+				>
+					<span>{ __( 'Permission Management', 'wedocs' ) }</span>
+				</a>
+			</UpgradePopup>
+		);
+	},
+	5
 );

--- a/src/data/docs/actions.js
+++ b/src/data/docs/actions.js
@@ -79,7 +79,7 @@ const actions = {
   *updateDoc( docId, data ) {
     const getDocsPath = wp.hooks.applyFilters(
       'wedocs_documentation_fetching_path',
-      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft' : ''}`
+      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
     );
     const path = '/wp/v2/docs/' + docId;
     yield { type: 'UPDATE_TO_API', path, data };
@@ -141,7 +141,7 @@ const actions = {
   *updateParentDocs() {
     const getDocsPath = wp.hooks.applyFilters(
       'wedocs_documentation_fetching_path',
-      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft' : ''}`
+      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
     );
 
     const response = yield actions.fetchFromAPI( getDocsPath );

--- a/src/data/docs/resolvers.js
+++ b/src/data/docs/resolvers.js
@@ -1,12 +1,13 @@
 import actions from './actions';
 
-const getDocsPath = wp.hooks.applyFilters(
-  'wedocs_documentation_fetching_path',
-  `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft' : ''}`
-);
-
 const resolvers = {
   *getDocs() {
+    // Compute path at runtime to ensure Pro filters are applied
+    const getDocsPath = wp.hooks.applyFilters(
+      'wedocs_documentation_fetching_path',
+      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
+    );
+    
     yield actions.setLoading( true );
     const response = yield actions.fetchFromAPI( getDocsPath );
     yield actions.setDocs( response );

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,12 @@ import './data/store';
 import './assets/css/index.css';
 import App from './components/App';
 import menuFix from './utils/menuFix';
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
-render( <App />, document.getElementById( 'wedocs-app' ) );
+// Wait for DOM and all scripts to be ready before rendering
+// This ensures Pro plugin filters are registered before App renders
 
+const container = document.getElementById( 'wedocs-app' );
+const root = createRoot( container );
+root.render( <App /> );
 menuFix( 'wedocs' );


### PR DESCRIPTION
- Remove static isProLoaded check evaluated at script load time
- Add dynamic runtime checks in all preview filters
- Rename all callback names to avoid conflicts with Pro plugin
- Add priority 5 to ensure Pro filters (priority 10) can override
- Remove wedocs_register_menu_routes filter from free plugin

Fixes issue where Permission Management, Assistant Widget, Layout & Styles, Social Share, and Contributors previews were still appearing in settings even when wedocs-pro plugin was active and licensed.

The root cause was the isProLoaded check happening at script parse time before Pro plugin loaded, causing all preview filters to register even when Pro was present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * UI now conditionally shows free-preview or hides elements when the Pro plugin is active, affecting settings, templates, restriction controls, contributors and menu previews.
* **User Experience**
  * Private/privacy option shows an upgrade prompt and a premium badge for non‑Pro users; admins see full private results.
* **Chores**
  * App routing adjusted so the "not found" catch‑all is evaluated after plugin routes; startup rendering updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->