### PR TITLE
fix: show promo notice on appropriate pages

### DIFF
--- a/includes/Admin/Promotion.php
+++ b/includes/Admin/Promotion.php
@@ -57,6 +57,12 @@ class Promotion {
 			&& strtotime( $promos['start_date'] ) < strtotime( $current_time )
 			&& strtotime( $current_time ) < strtotime( $promos['end_date'] )
 			) {
+			// Only show notice on dashboard, weDocs pages, and doc tags page.
+			$screen = get_current_screen();
+			if ( ! $screen || ! in_array( $screen->id, array( 'dashboard', 'toplevel_page_wedocs', 'edit-doc_tag' ), true ) ) {
+				return;
+			}
+
 			$this->generate_notice( $promos );
 		}
 	}


### PR DESCRIPTION
closes [#243](https://github.com/weDevsOfficial/wedocs-pro/issues/243)

Only show weDocs promotion to weDocs pages and wp dashboard instead of everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted promotional notice display to specific admin pages to reduce notification clutter in non-relevant areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->