### PR TITLE
Fix: Sensitive Information Exposure in Settings API Endpoint

### DIFF
--- a/includes/API/SettingsApi.php
+++ b/includes/API/SettingsApi.php
@@ -67,7 +67,7 @@ class SettingsApi extends \WP_REST_Controller {
                 array(
                     'methods'             => WP_REST_Server::READABLE,
                     'callback'            => array( $this, 'get_items' ),
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => array( $this, 'get_items_permissions_check' ),
                 ),
                 array(
                     'methods'             => WP_REST_Server::CREATABLE,
@@ -101,6 +101,23 @@ class SettingsApi extends \WP_REST_Controller {
                 ),
             )
         );
+    }
+
+    /**
+     * Check settings data read permission.
+     *
+     * @since 2.1.16
+     *
+     * @param \WP_REST_Request $request
+     *
+     * @return bool|WP_Error
+     */
+    public function get_items_permissions_check( $request ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return new \WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to do that.', 'wedocs' ), array( 'status' => rest_authorization_required_code() ) );
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Fix: Sensitive Information Exposure in Settings API Endpoint

Security Vulnerability Fix - High Severity

## Summary
Fixes unauthorized access to the /wp-json/wp/v2/docs/settings REST API endpoint 
that allowed unauthenticated users to access sensitive configuration data including 
third-party API keys (OpenAI, Anthropic, etc.).

## Vulnerability Details
- Affected Versions: All versions up to and including 2.1.15
- Severity: High
- Type: Missing Authorization / Sensitive Information Exposure
- Endpoint: GET /wp-json/wp/v2/docs/settings

## Changes Made
- Modified: includes/API/SettingsApi.php
  - Changed GET endpoint permission callback from '__return_true' to custom check
  - Added get_items_permissions_check() method requiring 'manage_options' capability
  - Only administrators can now access settings data

## Security Impact
- Before: Anyone could access API keys and sensitive settings (unauthenticated)
- After: Only administrators with proper capabilities can access settings

## Testing
- All security tests passing
- Unauthenticated access: Returns 401 Forbidden ✓
- Administrator access: Returns 200 OK ✓
- Non-admin users: Returns 403 Forbidden ✓

## Compatibility
- No breaking changes to existing admin functionality
- Turnstile site key endpoint remains public (as intended)
- POST endpoint authorization unchanged

### Test to reproduce 
`curl -i http://{SITE_BASE_URL}/wp-json/wp/v2/docs/settings\?data\=wedocs_settings 2>&1 | head -20`

Close [256](https://github.com/weDevsOfficial/wedocs-pro/issues/256)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings endpoints now enforce proper permission restrictions, ensuring only authorized administrators can access settings data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->