### PR TITLE
fix(security): restrict documentation editing to authorized roles only

### DIFF
--- a/includes/Upgrader/Upgrades/V_2_0_2.php
+++ b/includes/Upgrader/Upgrades/V_2_0_2.php
@@ -97,8 +97,8 @@ class V_2_0_2 extends UpgradeHandler {
             $wp_roles = new \WP_Roles(); // @codingStandardsIgnoreLine
         }
 
-        $permitted_roles = array( 'administrator', 'editor' );
-        $capabilities    = array(
+        $roles        = $wp_roles->get_names();
+        $capabilities = array(
             'edit_post',
             'edit_docs',
             'publish_docs',
@@ -108,12 +108,10 @@ class V_2_0_2 extends UpgradeHandler {
             'edit_published_docs'
         );
 
-        // Push documentation handling access ONLY to permitted roles.
+        // Push documentation handling access to users.
         foreach ( $capabilities as $capability ) {
-            foreach ( $permitted_roles as $role_key ) {
-                if ( $wp_roles->is_role( $role_key ) ) {
-                    $wp_roles->add_cap( $role_key, $capability );
-                }
+            foreach ( $roles as $role_key => $role ) {
+                $wp_roles->add_cap( $role_key, $capability );
             }
         }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -512,14 +512,10 @@ function wedocs_user_documentation_handling_capabilities() {
 
     $permitted_roles = array( 'administrator', 'editor' );
     $all_roles       = $wp_roles->get_names();
-    $capabilities    = array( 'edit_post', 'edit_docs', 'publish_docs', 'edit_others_docs', 'read_private_docs', 'edit_private_docs', 'edit_published_docs' );
+    $capabilities    = array( 'edit_docs', 'publish_docs', 'edit_others_docs', 'read_private_docs', 'edit_private_docs', 'edit_published_docs' );
 
     // First, remove capabilities from unauthorized roles (cleanup for existing installations)
     foreach ( $capabilities as $capability ) {
-        if ( 'edit_post' === $capability ) {
-            continue; // Skip core WordPress capability
-        }
-
         foreach ( array_keys( $all_roles ) as $role_key ) {
             $role = $wp_roles->get_role( $role_key );
             if ( $role && $role->has_cap( $capability ) && ! in_array( $role_key, $permitted_roles, true ) ) {


### PR DESCRIPTION
## Security Fix: CVE-2025-13921 - Missing Authorization

### Summary
Fixes a missing capability check vulnerability that allowed authenticated 
users with Subscriber-level access to edit any documentation post.

### Vulnerability Details
- **CVE**: CVE-2025-13921
- **Severity**: Medium (4.3 CVSS)
- **Affected Versions**: ≤ 2.1.15

### Changes
- `includes/functions.php` - Restricted `wedocs_user_documentation_handling_capabilities()` 
  to only grant capabilities to `administrator` and `editor` roles
- `includes/Upgrader/Upgrades/V_2_0_2.php` - Same fix applied to upgrader

### Testing
1. Log in as Subscriber
2. Try to access `/wp-admin/post.php?post={doc_id}&action=edit`
3. Verify access is denied ✅

Close [251](https://github.com/weDevsOfficial/wedocs-pro/issues/251)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved role-based access control for documentation handling capabilities. The system now precisely assigns documentation permissions to administrator and editor roles, with automatic cleanup of permissions on existing installations for better security and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->