### PR TITLE
Fix formattedDateString usage in article components

### DIFF
--- a/src/components/DocListing/ArticleChildrens.js
+++ b/src/components/DocListing/ArticleChildrens.js
@@ -234,7 +234,7 @@ const ArticleChildrens = ( { article, section, sections, setShowArticles, isAllo
                   { /* translators: %s: Formatted datetime string */ }
                   { sprintf(
                     __( 'Updated on %s', 'wedocs' ),
-                    formattedDateString
+                    formattedDateString()
                   ) }
                 </div>
               </div>

--- a/src/components/DocListing/SectionArticles.js
+++ b/src/components/DocListing/SectionArticles.js
@@ -318,7 +318,7 @@ const SectionArticles = ( { article, articles, isAdmin, section, sections, searc
                     { /* translators: %s: Formatted datetime string */ }
                     { sprintf(
                       __( 'Updated on %s', 'wedocs' ),
-                      formattedDateString
+                      formattedDateString()
                     ) }
                   </div>
                 </div>


### PR DESCRIPTION
Fix article creation date displaying raw JavaScript code instead of formatted date. Close #271 

- Add missing function call parentheses to formattedDateString() in SectionArticles.js and ArticleChildrens.js
- Resolves issue where "Updated on" field showed function code instead of formatted date like "Dec 23, 2025"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect rendering of updated date strings in article listings. Dates now display as properly formatted text instead of function references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->