### PR TITLE
Fix REST API 401 authentication errors by adding nonce middleware

### DIFF
--- a/src/data/docs/controls.js
+++ b/src/data/docs/controls.js
@@ -1,5 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 
+// Set up REST API nonce for authentication
+if ( typeof window.weDocsAdminVars !== 'undefined' && window.weDocsAdminVars.restNonce ) {
+  apiFetch.use( apiFetch.createNonceMiddleware( window.weDocsAdminVars.restNonce ) );
+}
+
 const controls = {
   FETCH_FROM_API( action ) {
     return apiFetch( { path: action.path } );

--- a/src/data/settings/controls.js
+++ b/src/data/settings/controls.js
@@ -1,5 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 
+// Set up REST API nonce for authentication
+if ( typeof window.weDocsAdminVars !== 'undefined' && window.weDocsAdminVars.restNonce ) {
+  apiFetch.use( apiFetch.createNonceMiddleware( window.weDocsAdminVars.restNonce ) );
+}
+
 const isProLoaded = wp.hooks.applyFilters(
   'wedocs_pro_loaded',
   false


### PR DESCRIPTION
Fix REST API 401 authentication errors by adding nonce middleware

- Add restNonce to weDocsAdminVars in Assets.php
- Configure apiFetch nonce middleware in docs and settings controls
- Remove duplicate adminUrl and hasManageCap entries in Assets.php
- Import apiFetch in aiService.js and convert WordPress REST API calls
- Ensures proper authentication for all REST API requests in admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Streamlined REST API authentication and security
  * Enhanced error handling with clearer messages for AI-related operations
  * Improved consistency in API response handling across the application

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->