### PR TITLE
Fix 3-dot action menu overlapping between article rows

### DIFF
--- a/src/components/DocActions.js
+++ b/src/components/DocActions.js
@@ -46,7 +46,7 @@ const DocActions = ( { doc, type, section, sections, setShowArticles } ) => {
   return (
     <Fragment>
       <div
-        className="documentation-ellipsis-actions relative"
+        className={ `documentation-ellipsis-actions relative ${ showActions ? 'z-50' : '' }` }
         onMouseEnter={ () => setShowActions( true ) }
         onMouseLeave={ () => setShowActions( false ) }
       >


### PR DESCRIPTION
Fix 3-dot action menu overlapping between article rows
Close #277 

The dropdown menu from one article row was appearing behind another row's 
menu button due to stacking context issues. Added dynamic z-index (z-50) 
to the parent container when the menu is active, ensuring it always 
renders above other rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved z-index layering to ensure UI elements display correctly when actions are shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->