### PR TITLE
Security Fix: Restrict documentation editing capabilities to authorized roles only

### DIFF
--- a/includes/Upgrader/Abstracts/UpgradeHandler.php
+++ b/includes/Upgrader/Abstracts/UpgradeHandler.php
@@ -44,8 +44,11 @@ abstract class UpgradeHandler {
         if ( $need_upgrade ) {
             $this->handle_upgrade();
             update_option( 'wedocs_version', $this->version );
-            $this->next();
         }
+
+        // Always call next() to continue the upgrade chain,
+        // even if this upgrade didn't need to run
+        $this->next();
     }
 
     /**

--- a/includes/Upgrader/Upgrades/Upgrades.php
+++ b/includes/Upgrader/Upgrades/Upgrades.php
@@ -11,7 +11,10 @@ class Upgrades {
      *
      * @since 2.0.2
      */
-    public $class_list = array( '2.0.2' => V_2_0_2::class );
+    public $class_list = array(
+        '2.0.2'  => V_2_0_2::class,
+        '2.1.17' => V_2_1_17::class,
+    );
 
     /**
      * Get wedocs installed version number.

--- a/includes/Upgrader/Upgrades/V_2_0_2.php
+++ b/includes/Upgrader/Upgrades/V_2_0_2.php
@@ -91,28 +91,7 @@ class V_2_0_2 extends UpgradeHandler {
      * @return void
      */
     private function add_documentation_handling_capabilities() {
-        global $wp_roles;
-
-        if ( class_exists( 'WP_Roles' ) && ! isset( $wp_roles ) ) {
-            $wp_roles = new \WP_Roles(); // @codingStandardsIgnoreLine
-        }
-
-        $roles        = $wp_roles->get_names();
-        $capabilities = array(
-            'edit_post',
-            'edit_docs',
-            'publish_docs',
-            'edit_others_docs',
-            'read_private_docs',
-            'edit_private_docs',
-            'edit_published_docs'
-        );
-
-        // Push documentation handling access to users.
-        foreach ( $capabilities as $capability ) {
-            foreach ( $roles as $role_key => $role ) {
-                $wp_roles->add_cap( $role_key, $capability );
-            }
-        }
+        // Use the centralized function that restricts capabilities to administrator and editor only.
+        wedocs_user_documentation_handling_capabilities();
     }
 }

--- a/includes/Upgrader/Upgrades/V_2_1_17.php
+++ b/includes/Upgrader/Upgrades/V_2_1_17.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WeDevs\WeDocs\Upgrader\Upgrades;
+
+use WeDevs\WeDocs\Upgrader\Abstracts\UpgradeHandler;
+
+/**
+ * Upgrade handler for version 2.1.17.
+ *
+ * Security fix: Remove documentation editing capabilities from unauthorized roles.
+ */
+class V_2_1_17 extends UpgradeHandler {
+
+    /**
+     * Upgrade version.
+     *
+     * @since 2.1.17
+     *
+     * @var string
+     */
+    protected $version = '2.1.17';
+
+    /**
+     * Upgrade necessary data in database.
+     *
+     * @since 2.1.17
+     *
+     * @return void
+     */
+    public function handle_upgrade() {
+        $this->fix_documentation_capabilities();
+    }
+
+    /**
+     * Fix documentation handling capabilities.
+     *
+     * Removes editing capabilities from unauthorized roles (Subscriber, Contributor, Author)
+     * that were incorrectly granted in previous versions. Only Administrator and Editor
+     * should have documentation editing capabilities.
+     *
+     * @since 2.1.17
+     *
+     * @return void
+     */
+    private function fix_documentation_capabilities() {
+        wedocs_user_documentation_handling_capabilities();
+    }
+}


### PR DESCRIPTION
Security Fix: Restrict documentation editing capabilities to authorized roles only

This patch addresses CVE-2025-13921 where documentation editing capabilities 
were incorrectly granted to all user roles including Subscriber.

Changes:
- V_2_0_2.php: Use centralized capability function instead of granting to all roles
- V_2_1_17.php: New migration to remove capabilities from unauthorized roles on update
- Upgrades.php: Register V_2_1_17 upgrade handler
- Version bumped to 2.1.17

Affected capabilities now restricted to Administrator and Editor only:
- edit_docs
- publish_docs
- edit_others_docs
- read_private_docs
- edit_private_docs
- edit_published_docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for the 2.1.17 upgrade path.

* **Security Updates**
  * Documentation editing permissions are restricted to Administrators and Editors.

* **System Improvements**
  * Upgrade flow strengthened to always continue after checks.
  * Consolidated capability handling for more reliable permission updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->