### PR TITLE
Remove Pro available admin notice logic

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -16,7 +16,6 @@ class Admin {
         add_filter( 'parent_file', [ $this, 'fix_tag_menu' ], 15 );
         add_filter( 'submenu_file', [ $this, 'highlight_admin_submenu' ] );
         add_filter( 'admin_footer_text', [ $this, 'admin_footer_text' ], 1 );
-        add_action( 'admin_notices', [ $this, 'show_wedocs_pro_available_notice' ] );
 
 		if ( ! wedocs_pro_exists() ) {
 			new Promotion();
@@ -63,26 +62,6 @@ class Admin {
         return $submenu_file;
     }
 
-    /**
-     * Show weDocs pro available notices.
-     *
-     * @since 2.0.0
-     *
-     * @return void
-     */
-    public function show_wedocs_pro_available_notice() {
-        if ( wedocs_pro_exists() ) {
-            return;
-        }
-
-        // Check if the admin notice should be hidden based on the user meta.
-        $user_id     = get_current_user_id();
-        $hide_notice = get_user_meta( $user_id, 'wedocs_hide_pro_notice', true );
-        if ( ! $hide_notice ) {
-            // Render weDocs pro info notice.
-            wedocs_get_template_part( 'pro', 'notice' );
-        }
-    }
 
     /**
      * Change the admin footer text on weDocs admin pages.


### PR DESCRIPTION
Eliminated the show_wedocs_pro_available_notice method and its related admin_notices hook. This streamlines the admin interface by removing the Pro promotion notice logic.
fixes : https://github.com/weDevsOfficial/wedocs-plugin/pull/283
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the pro-availability notice that was displayed in the admin area.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->