### PR TITLE
Add pagination to wedocs shortcode

### DIFF
--- a/includes/Shortcode.php
+++ b/includes/Shortcode.php
@@ -76,7 +76,10 @@ class Shortcode {
         $current_page = 1;
 
         if ( $per_page > 0 && $total_docs > $per_page ) {
-            $current_page = max( 1, absint( isset( $_GET['wedocs_page'] ) ? $_GET['wedocs_page'] : 1 ) );
+            $raw_page     = isset( $_GET['wedocs_page'] ) && is_scalar( $_GET['wedocs_page'] )
+                                ? wp_unslash( $_GET['wedocs_page'] )
+                                : 1;
+            $current_page = max( 1, absint( $raw_page ) );
             $total_pages  = (int) ceil( $total_docs / $per_page );
             $current_page = min( $current_page, $total_pages );
             $offset       = ( $current_page - 1 ) * $per_page;

--- a/includes/Shortcode.php
+++ b/includes/Shortcode.php
@@ -41,11 +41,12 @@ class Shortcode {
      */
     public static function wedocs( $args = [] ) {
         $defaults = [
-            'col'     => '2',
-            'include' => 'any',
-            'exclude' => '',
-            'items'   => 10,
-            'more'    => __( 'View Details', 'wedocs' ),
+            'col'      => '2',
+            'include'  => 'any',
+            'exclude'  => '',
+            'items'    => 10,
+            'more'     => __( 'View Details', 'wedocs' ),
+            'paginate' => '',
         ];
 
         $args     = wp_parse_args( $args, $defaults );
@@ -67,6 +68,20 @@ class Shortcode {
 
         $parent_args = apply_filters( 'wedocs_shortcode_page_parent_args', $parent_args );
         $parent_docs = get_pages( $parent_args );
+
+        // Pagination support.
+        $per_page    = ! empty( $args['paginate'] ) ? absint( $args['paginate'] ) : 0;
+        $total_docs  = is_array( $parent_docs ) ? count( $parent_docs ) : 0;
+        $total_pages = 1;
+        $current_page = 1;
+
+        if ( $per_page > 0 && $total_docs > $per_page ) {
+            $current_page = max( 1, absint( isset( $_GET['wedocs_page'] ) ? $_GET['wedocs_page'] : 1 ) );
+            $total_pages  = (int) ceil( $total_docs / $per_page );
+            $current_page = min( $current_page, $total_pages );
+            $offset       = ( $current_page - 1 ) * $per_page;
+            $parent_docs  = array_slice( $parent_docs, $offset, $per_page );
+        }
 
         // Arrange the section docs.
         if ( $parent_docs ) {
@@ -120,6 +135,8 @@ class Shortcode {
                 'more'          => $args['more'],
                 'col'           => (int) ( $docs_length === 1 ? $docs_length : $args['col'] ),
                 'enable_search' => wedocs_get_general_settings( 'enable_search', 'on' ),
+                'current_page'  => $current_page,
+                'total_pages'   => $total_pages,
             )
         );
 

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -99,6 +99,73 @@ if ( $docs ) {
             </li>
         <?php } ?>
     </ul>
+
+    <?php if ( ! empty( $total_pages ) && $total_pages > 1 ) : ?>
+        <nav class="wedocs-pagination">
+            <?php if ( $current_page > 1 ) : ?>
+                <a href="<?php echo esc_url( add_query_arg( 'wedocs_page', $current_page - 1 ) ); ?>" class="wedocs-pagination__prev">
+                    &larr; <?php esc_html_e( 'Previous', 'wedocs' ); ?>
+                </a>
+            <?php else : ?>
+                <span class="wedocs-pagination__prev wedocs-pagination__disabled">
+                    &larr; <?php esc_html_e( 'Previous', 'wedocs' ); ?>
+                </span>
+            <?php endif; ?>
+
+            <span class="wedocs-pagination__info">
+                <?php printf( esc_html__( 'Page %1$d of %2$d', 'wedocs' ), $current_page, $total_pages ); ?>
+            </span>
+
+            <?php if ( $current_page < $total_pages ) : ?>
+                <a href="<?php echo esc_url( add_query_arg( 'wedocs_page', $current_page + 1 ) ); ?>" class="wedocs-pagination__next">
+                    <?php esc_html_e( 'Next', 'wedocs' ); ?> &rarr;
+                </a>
+            <?php else : ?>
+                <span class="wedocs-pagination__next wedocs-pagination__disabled">
+                    <?php esc_html_e( 'Next', 'wedocs' ); ?> &rarr;
+                </span>
+            <?php endif; ?>
+        </nav>
+
+        <style>
+            .wedocs-pagination {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 16px;
+                margin-top: 30px;
+                padding: 12px 0;
+            }
+            .wedocs-pagination__prev,
+            .wedocs-pagination__next {
+                display: inline-flex;
+                align-items: center;
+                padding: 8px 18px;
+                border-radius: 6px;
+                text-decoration: none;
+                font-size: 14px;
+                font-weight: 500;
+                border: 1px solid currentColor;
+                color: inherit;
+                transition: opacity 0.2s ease;
+            }
+            .wedocs-pagination__prev:hover,
+            .wedocs-pagination__next:hover {
+                opacity: 0.75;
+            }
+            .wedocs-pagination__disabled {
+                opacity: 0.4;
+                pointer-events: none;
+                cursor: default;
+            }
+            .wedocs-pagination__info {
+                font-size: 14px;
+                color: inherit;
+                opacity: 0.7;
+            }
+        </style>
+    <?php endif; ?>
+
 </div>
 
 <?php }


### PR DESCRIPTION
Introduce optional pagination for the [wedocs] shortcode via a new 'paginate' attribute. When 'paginate' is set > 0 the code computes per-page limits, total pages and current page (from $_GET['wedocs_page']), bounds and sanitizes values with absint/max/min, and slices the pages array accordingly. current_page and total_pages are passed to the template, which now renders previous/next links, page info and minimal styles. Pagination is opt-in (backward compatible when 'paginate' is empty).

fixes #296 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to wedocs shortcode so long content can be split across multiple pages.
  * Added Previous/Next navigation with disabled states at first/last page.
  * Added page counter showing current page and total pages.
  * Pagination state is exposed to templates so UI reflects current page.
  * Included basic styling for the pagination controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->