### PR TITLE
Preserve AI integration flag when saving settings

### DIFF
--- a/includes/API/SettingsApi.php
+++ b/includes/API/SettingsApi.php
@@ -200,7 +200,7 @@ class SettingsApi extends \WP_REST_Controller {
 
         // Preserve integrate_ai (AI connection state) when saving general settings.
         $existing_settings = get_option( 'wedocs_settings', [] );
-        if ( ! empty( $existing_settings['integrate_ai'] ) && empty( $settings_data_filtered['integrate_ai'] ) ) {
+        if ( array_key_exists( 'integrate_ai', $existing_settings ) && ! array_key_exists( 'integrate_ai', $settings_data_filtered ) ) {
             $settings_data_filtered['integrate_ai'] = $existing_settings['integrate_ai'];
         }
 

--- a/includes/API/SettingsApi.php
+++ b/includes/API/SettingsApi.php
@@ -198,6 +198,12 @@ class SettingsApi extends \WP_REST_Controller {
         
         $settings_data_filtered = apply_filters( 'wedocs_settings_data', $settings_data );
 
+        // Preserve integrate_ai (AI connection state) when saving general settings.
+        $existing_settings = get_option( 'wedocs_settings', [] );
+        if ( ! empty( $existing_settings['integrate_ai'] ) && empty( $settings_data_filtered['integrate_ai'] ) ) {
+            $settings_data_filtered['integrate_ai'] = $existing_settings['integrate_ai'];
+        }
+
         // Update wedocs_settings via docs store.
         update_option( 'wedocs_settings', $settings_data_filtered );
         $response = apply_filters( 'wedocs_settings_data_rest_response', $settings_data_filtered, $settings_data );


### PR DESCRIPTION
When updating wedocs_settings, preserve the existing integrate_ai value if the incoming payload omits or clears it. The code reads the current option and copies integrate_ai into the filtered settings when present, preventing accidental clearing of the AI connection state during general settings updates.
related PRO [PR](https://github.com/weDevsOfficial/wedocs-pro/pull/283)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the AI integration setting could be cleared when saving other settings.
  * Settings updates now preserve the existing AI connection state if the incoming update does not include that value, preventing unintended loss of AI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->