### PR TITLE
Close style block in doc search form

### DIFF
--- a/templates/doc-search-form.php
+++ b/templates/doc-search-form.php
@@ -6,6 +6,8 @@
 .wedocs-single-search-input .search-field {
     padding-right: 50px !important;
     padding-left: 22px !important;
+}
+</style>
 <form role='search' method='get' class='search-form wedocs-search-form wedocs-single-search-input' action='<?php echo esc_url( home_url( '/' ) ) ?>'>
     <div class='wedocs-search-input'>
         <input


### PR DESCRIPTION
Add the missing closing curly brace and </style> tag to templates/doc-search-form.php to properly terminate the inline CSS block. This prevents broken markup/CSS leakage and fixes the search form layout.
fixes https://github.com/weDevsOfficial/wedocs-pro/issues/288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS styling in the document search form to ensure the search input field displays with proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->