### PR TITLE
Change default avatar border radius to 8px

### DIFF
--- a/src/blocks/Contributors/block.json
+++ b/src/blocks/Contributors/block.json
@@ -183,7 +183,7 @@
 		},
 		"avatarBorderRadius": {
 			"type": "string",
-			"default": "50%"
+			"default": "8px"
 		},
 		"avatarHoverEffect": {
 			"type": "boolean",

--- a/src/blocks/Contributors/edit.js
+++ b/src/blocks/Contributors/edit.js
@@ -487,7 +487,10 @@ const Edit = (props) => {
 								{ label: __('Rounded', 'wedocs'), value: 'rounded' },
 								{ label: __('Square', 'wedocs'), value: 'square' }
 							]}
-							onChange={(value) => setAttributes({ avatarShape: value })}
+							onChange={(value) => {
+								const shapeDefaults = { circle: '50%', rounded: '8px', square: '0' };
+								setAttributes({ avatarShape: value, avatarBorderRadius: shapeDefaults[value] });
+							}}
 						/>
 
 						<ToggleControl

--- a/src/blocks/Contributors/edit.js
+++ b/src/blocks/Contributors/edit.js
@@ -210,8 +210,7 @@ const Edit = (props) => {
 		const avatarStyle = {
 			width: attributes.avatarSize,
 			height: attributes.avatarSize,
-			borderRadius: attributes.avatarShape === 'circle' ? '50%' :
-				(attributes.avatarShape === 'rounded' ? attributes.avatarBorderRadius : '0'),
+			borderRadius: attributes.avatarBorderRadius,
 			borderStyle: attributes.avatarBorderStyle !== 'none' ? attributes.avatarBorderStyle : undefined,
 			borderColor: attributes.avatarBorderStyle !== 'none' ? attributes.avatarBorderColor : undefined,
 			borderWidth: attributes.avatarBorderStyle !== 'none' ?
@@ -481,16 +480,13 @@ const Edit = (props) => {
 
 						<SelectControl
 							label={__('Avatar Shape', 'wedocs')}
-							value={attributes.avatarShape}
+							value={attributes.avatarBorderRadius}
 							options={[
-								{ label: __('Circle', 'wedocs'), value: 'circle' },
-								{ label: __('Rounded', 'wedocs'), value: 'rounded' },
-								{ label: __('Square', 'wedocs'), value: 'square' }
+								{ label: __('Circle', 'wedocs'), value: '50%' },
+								{ label: __('Rounded', 'wedocs'), value: '8px' },
+								{ label: __('Square', 'wedocs'), value: '0' }
 							]}
-							onChange={(value) => {
-								const shapeDefaults = { circle: '50%', rounded: '8px', square: '0' };
-								setAttributes({ avatarShape: value, avatarBorderRadius: shapeDefaults[value] });
-							}}
+							onChange={(value) => setAttributes({ avatarBorderRadius: value })}
 						/>
 
 						<ToggleControl
@@ -644,11 +640,9 @@ const Edit = (props) => {
 						borderStyle={attributes.avatarBorderStyle}
 						borderWidth={attributes.avatarBorderWidth}
 						borderColor={attributes.avatarBorderColor}
-						borderRadius={attributes.avatarBorderRadius}
 						onStyleChange={(value) => setAttributes({ avatarBorderStyle: value })}
 						onWidthChange={(value) => setAttributes({ avatarBorderWidth: value })}
 						onColorChange={(value) => setAttributes({ avatarBorderColor: value })}
-						onRadiusChange={(value) => setAttributes({ avatarBorderRadius: value })}
 					/>
 				</>
 			)}

--- a/src/blocks/Contributors/render.php
+++ b/src/blocks/Contributors/render.php
@@ -32,7 +32,6 @@ if ( !function_exists('render_wedocs_contributors_block')){
         $show_avatar = $attributes['showAvatar'] ?? true;
         $avatar_type = $attributes['avatarType'] ?? 'user_avatar';
         $avatar_size = $attributes['avatarSize'] ?? '32px';
-        $avatar_shape = $attributes['avatarShape'] ?? 'circle';
         $avatar_border_style = $attributes['avatarBorderStyle'] ?? 'none';
         $avatar_border_color = $attributes['avatarBorderColor'] ?? '#dddddd';
         $avatar_hover_effect = $attributes['avatarHoverEffect'] ?? false;
@@ -176,17 +175,7 @@ if ( !function_exists('render_wedocs_contributors_block')){
         ];
 
         // Avatar shape
-        switch ($avatar_shape) {
-            case 'circle':
-                $avatar_base_styles[] = 'border-radius: 50%';
-                break;
-            case 'rounded':
-                $avatar_base_styles[] = 'border-radius: ' . esc_attr($attributes['avatarBorderRadius'] ?? '8px');
-                break;
-            case 'square':
-                $avatar_base_styles[] = 'border-radius: 0';
-                break;
-        }
+        $avatar_base_styles[] = 'border-radius: ' . esc_attr($attributes['avatarBorderRadius'] ?? '50%');
 
         // Avatar border and spacing
         $avatar_styles = array_merge($avatar_base_styles, wedocs_build_border_styles(


### PR DESCRIPTION
Update Contributors block config to use an 8px default for avatarBorderRadius instead of 50%. This changes avatars from fully circular to slightly rounded rectangles to better match the current design language and spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Default contributor avatars now use softer, moderately rounded corners instead of a fully circular crop for a refined profile appearance.

* **New Features**
  * Avatar shape selector now directly controls corner rounding and updates the displayed avatar immediately so selection matches the preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->