### PR TITLE
feature: implement GDPR for user submitted message (recover #308)

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -192,7 +192,21 @@
       const self = $( this ),
         submit = self.find( 'input[type=submit]' ),
         body = self.closest( '.wedocs-modal-body' ),
-        data = self.serialize() + '&_wpnonce=' + weDocs_Vars.nonce;
+        consentCheckbox = self.find( '#wedocs-gdpr-consent' );
+
+      // Validate GDPR consent if checkbox exists.
+      if ( consentCheckbox.length && ! consentCheckbox.is( ':checked' ) ) {
+        $( '#wedocs-modal-errors', body )
+          .empty()
+          .append(
+            '<div class="wedocs-alert wedocs-alert-danger">' +
+              weDocs_Vars.gdprConsentError +
+              '</div>'
+          );
+        return;
+      }
+
+      const data = self.serialize() + '&_wpnonce=' + weDocs_Vars.nonce;
 
       submit.prop( 'disabled', true );
 

--- a/includes/API/API.php
+++ b/includes/API/API.php
@@ -39,6 +39,10 @@ class API extends WP_REST_Controller {
         // Register upgrader api.
         $upgrader_api = new UpgraderApi( $api );
         $upgrader_api->register_api();
+
+        // Register messages api.
+        $messages_api = new MessagesApi( $api );
+        $messages_api->register_api();
     }
 
     /**
@@ -641,6 +645,18 @@ class API extends WP_REST_Controller {
             $name  = $user->display_name;
             $email = $user->user_email;
         }
+
+        $email_to = wedocs_get_general_settings( 'email_to', get_option( 'admin_email' ) );
+
+        do_action( 'wedocs_before_send_contact_email', [
+            'name'       => $name,
+            'email'      => $email,
+            'subject'    => $request['subject'],
+            'message'    => $request['message'],
+            'doc_id'     => $id,
+            'recipients' => $email_to,
+            'source'     => 'modal',
+        ] );
 
         wedocs_doc_feedback_email( $id, $name, $email, $request['subject'], $request['message'] );
 

--- a/includes/API/MessagesApi.php
+++ b/includes/API/MessagesApi.php
@@ -1,0 +1,301 @@
+<?php
+// DESCRIPTION: REST API controller for managing stored contact messages.
+// Provides list, get, and delete endpoints for the admin messages UI.
+
+namespace WeDevs\WeDocs\API;
+
+use WP_Error;
+use WP_REST_Server;
+
+/**
+ * Messages REST API controller.
+ *
+ * @since WEDOCS_SINCE
+ */
+class MessagesApi extends \WP_REST_Controller {
+
+    /**
+     * Post Type Base.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @var string
+     */
+    protected $base = 'docs/messages';
+
+    /**
+     * WP Version Number.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @var string
+     */
+    protected $version = '2';
+
+    /**
+     * WP Version Slug.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @var string
+     */
+    protected $namespace = 'wp/v';
+
+    /**
+     * Parent API class.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @var \WeDevs\WeDocs\API
+     */
+    protected $api;
+
+    /**
+     * Initialize the class.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param \WeDevs\WeDocs\API $api Parent API instance.
+     */
+    public function __construct( $api ) {
+        $this->api = $api;
+    }
+
+    /**
+     * Register messages API routes.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @return void
+     */
+    public function register_api() {
+        register_rest_route( $this->namespace . $this->version, '/' . $this->base,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_items' ),
+                    'permission_callback' => array( $this, 'admin_permissions_check' ),
+                    'args'                => array(
+                        'page' => array(
+                            'type'              => 'integer',
+                            'default'           => 1,
+                            'sanitize_callback' => 'absint',
+                        ),
+                        'per_page' => array(
+                            'type'              => 'integer',
+                            'default'           => 20,
+                            'sanitize_callback' => 'absint',
+                        ),
+                        'search' => array(
+                            'type'              => 'string',
+                            'default'           => '',
+                            'sanitize_callback' => 'sanitize_text_field',
+                        ),
+                        'source' => array(
+                            'type'              => 'string',
+                            'default'           => '',
+                            'enum'              => array( '', 'modal', 'widget' ),
+                            'sanitize_callback' => 'sanitize_text_field',
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        register_rest_route( $this->namespace . $this->version, '/' . $this->base . '/(?P<id>[\d]+)',
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_item' ),
+                    'permission_callback' => array( $this, 'admin_permissions_check' ),
+                ),
+                array(
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => array( $this, 'delete_item' ),
+                    'permission_callback' => array( $this, 'admin_permissions_check' ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Check admin permissions.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param \WP_REST_Request $request Full data about the request.
+     *
+     * @return bool|WP_Error
+     */
+    public function admin_permissions_check( $request ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return new WP_Error(
+                'rest_forbidden',
+                __( 'Sorry, you are not allowed to do that.', 'wedocs' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the messages table exists in the database.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @return bool|WP_Error True if table exists, WP_Error if not.
+     */
+    private function check_table_exists() {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wedocs_messages';
+        $table_exists = $wpdb->get_var(
+            $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+        );
+
+        if ( ! $table_exists ) {
+            return new WP_Error(
+                'rest_table_not_found',
+                __( 'The messages database table does not exist. Please deactivate and reactivate the weDocs plugin to create it.', 'wedocs' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Get a paginated list of messages.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param \WP_REST_Request $request Full data about the request.
+     *
+     * @return \WP_REST_Response|WP_Error
+     */
+    public function get_items( $request ) {
+        $table_check = $this->check_table_exists();
+        if ( is_wp_error( $table_check ) ) {
+            return $table_check;
+        }
+
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wedocs_messages';
+        $page       = $request->get_param( 'page' );
+        $per_page   = $request->get_param( 'per_page' );
+        $search     = $request->get_param( 'search' );
+        $source     = $request->get_param( 'source' );
+        $offset     = ( $page - 1 ) * $per_page;
+
+        $where_clauses = array();
+        $where_values  = array();
+
+        if ( ! empty( $search ) ) {
+            $like            = '%' . $wpdb->esc_like( $search ) . '%';
+            $where_clauses[] = '(name LIKE %s OR email LIKE %s OR subject LIKE %s OR message LIKE %s)';
+            $where_values[]  = $like;
+            $where_values[]  = $like;
+            $where_values[]  = $like;
+            $where_values[]  = $like;
+        }
+
+        if ( ! empty( $source ) ) {
+            $where_clauses[] = 'source = %s';
+            $where_values[]  = $source;
+        }
+
+        $where = '';
+        if ( ! empty( $where_clauses ) ) {
+            $where = 'WHERE ' . implode( ' AND ', $where_clauses );
+        }
+
+        // Get total count.
+        $count_query = "SELECT COUNT(*) FROM $table_name $where";
+        if ( ! empty( $where_values ) ) {
+            $count_query = $wpdb->prepare( $count_query, $where_values );
+        }
+        $total = (int) $wpdb->get_var( $count_query );
+
+        // Get paginated results.
+        $query = "SELECT * FROM $table_name $where ORDER BY submitted_at DESC LIMIT %d OFFSET %d";
+        $query_values = array_merge( $where_values, array( $per_page, $offset ) );
+        $messages = $wpdb->get_results( $wpdb->prepare( $query, $query_values ) );
+
+        return rest_ensure_response( array(
+            'messages'    => $messages,
+            'total'       => $total,
+            'total_pages' => ceil( $total / $per_page ),
+        ) );
+    }
+
+    /**
+     * Get a single message by ID.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param \WP_REST_Request $request Full data about the request.
+     *
+     * @return \WP_REST_Response|WP_Error
+     */
+    public function get_item( $request ) {
+        $table_check = $this->check_table_exists();
+        if ( is_wp_error( $table_check ) ) {
+            return $table_check;
+        }
+
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wedocs_messages';
+        $id         = (int) $request['id'];
+
+        $message = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table_name WHERE id = %d", $id ) );
+
+        if ( ! $message ) {
+            return new WP_Error(
+                'rest_message_not_found',
+                __( 'Message not found.', 'wedocs' ),
+                array( 'status' => 404 )
+            );
+        }
+
+        return rest_ensure_response( $message );
+    }
+
+    /**
+     * Delete a single message by ID.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param \WP_REST_Request $request Full data about the request.
+     *
+     * @return \WP_REST_Response|WP_Error
+     */
+    public function delete_item( $request ) {
+        $table_check = $this->check_table_exists();
+        if ( is_wp_error( $table_check ) ) {
+            return $table_check;
+        }
+
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wedocs_messages';
+        $id         = (int) $request['id'];
+
+        $deleted = $wpdb->delete( $table_name, array( 'id' => $id ), array( '%d' ) );
+
+        if ( ! $deleted ) {
+            return new WP_Error(
+                'rest_message_not_found',
+                __( 'Message not found.', 'wedocs' ),
+                array( 'status' => 404 )
+            );
+        }
+
+        return rest_ensure_response( array(
+            'success' => true,
+            'message' => __( 'Message deleted successfully.', 'wedocs' ),
+        ) );
+    }
+}

--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -79,6 +79,11 @@ class Menu {
                 'edit-tags.php?taxonomy=doc_tag&post_type=docs',
             ),
             array(
+                __( 'Messages', 'wedocs' ),
+                $this->capability,
+                $base . '#/messages',
+            ),
+            array(
                 __( 'Settings', 'wedocs' ),
                 apply_filters( 'wedocs_settings_management_capabilities', $this->capability ),
                 $base . '#/settings',

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -228,6 +228,18 @@ class Ajax {
             wp_send_json_error(__('Please provide the message details.', 'wedocs'));
         }
 
+        $email_to = wedocs_get_general_settings( 'email_to', get_option( 'admin_email' ) );
+
+        do_action( 'wedocs_before_send_contact_email', [
+            'name'       => $name,
+            'email'      => $email,
+            'subject'    => $subject,
+            'message'    => $message,
+            'doc_id'     => $doc_id,
+            'recipients' => $email_to,
+            'source'     => 'modal',
+        ] );
+
         wedocs_doc_feedback_email($doc_id, $name, $email, $subject, $message);
 
         wp_send_json_success(__('Thanks for your feedback.', 'wedocs'));

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -80,6 +80,7 @@ class Assets {
                     'dokan_active'  => is_plugin_active( 'dokan-lite/dokan.php' ),
                     'upgradePopupContent' => wedocs_get_upgrade_popup_content(),
                     'siteUrl'       => home_url( '/' ),
+                    'gdpr'          => wedocs_get_gdpr_frontend_settings(),
                 ),
             );
         }

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -116,6 +116,7 @@ class Frontend {
             'searchEmptyMsg'    => __( 'Your search didn\'t match any documents', 'wedocs' ),
             'sectionNavLabel'   => __( 'Section: ', 'wedocs' ),
             'searchModalColors' => wedocs_get_search_modal_active_colors(),
+            'gdprConsentError'  => __( 'You must accept the privacy policy to submit this form.', 'wedocs' ),
         ] );
     }
 

--- a/includes/Installer.php
+++ b/includes/Installer.php
@@ -19,6 +19,8 @@ class Installer {
         $this->add_post_types();
         $this->timestamps();
         wedocs_user_documentation_handling_capabilities();
+        wedocs_create_messages_table();
+        wedocs_add_messages_delete_after_column();
     }
 
     /**

--- a/includes/Privacy.php
+++ b/includes/Privacy.php
@@ -1,0 +1,199 @@
+<?php
+// DESCRIPTION: WordPress Privacy API integration for weDocs messages.
+// Registers data exporter and eraser for GDPR compliance.
+
+namespace WeDevs\WeDocs;
+
+/**
+ * Privacy class for WordPress Privacy API integration.
+ *
+ * @since WEDOCS_SINCE
+ */
+class Privacy {
+
+    /**
+     * Initialize privacy hooks.
+     *
+     * @since WEDOCS_SINCE
+     */
+    public function __construct() {
+        add_filter( 'wp_privacy_personal_data_exporters', [ $this, 'register_exporter' ] );
+        add_filter( 'wp_privacy_personal_data_erasers', [ $this, 'register_eraser' ] );
+    }
+
+    /**
+     * Register the data exporter for weDocs messages.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param array $exporters Existing exporters.
+     *
+     * @return array
+     */
+    public function register_exporter( $exporters ) {
+        $exporters['wedocs-messages'] = [
+            'exporter_friendly_name' => __( 'weDocs Messages', 'wedocs' ),
+            'callback'               => [ $this, 'export_messages' ],
+        ];
+
+        return $exporters;
+    }
+
+    /**
+     * Register the data eraser for weDocs messages.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param array $erasers Existing erasers.
+     *
+     * @return array
+     */
+    public function register_eraser( $erasers ) {
+        $erasers['wedocs-messages'] = [
+            'eraser_friendly_name' => __( 'weDocs Messages', 'wedocs' ),
+            'callback'             => [ $this, 'erase_messages' ],
+        ];
+
+        return $erasers;
+    }
+
+    /**
+     * Export personal data for the given email address.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param string $email_address Email address to export data for.
+     * @param int    $page          Page number for batched export.
+     *
+     * @return array
+     */
+    public function export_messages( $email_address, $page = 1 ) {
+        global $wpdb;
+
+        $table_name  = $wpdb->prefix . 'wedocs_messages';
+        $per_page    = 100;
+        $offset      = ( $page - 1 ) * $per_page;
+        $export_items = [];
+
+        // Check if table exists.
+        $table_exists = $wpdb->get_var(
+            $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+        );
+
+        if ( ! $table_exists ) {
+            return [
+                'data' => [],
+                'done' => true,
+            ];
+        }
+
+        $messages = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM $table_name WHERE email = %s ORDER BY submitted_at DESC LIMIT %d OFFSET %d",
+                $email_address,
+                $per_page,
+                $offset
+            )
+        );
+
+        foreach ( $messages as $message ) {
+            $data = [
+                [
+                    'name'  => __( 'Name', 'wedocs' ),
+                    'value' => $message->name,
+                ],
+                [
+                    'name'  => __( 'Email', 'wedocs' ),
+                    'value' => $message->email,
+                ],
+                [
+                    'name'  => __( 'Subject', 'wedocs' ),
+                    'value' => $message->subject,
+                ],
+                [
+                    'name'  => __( 'Message', 'wedocs' ),
+                    'value' => $message->message,
+                ],
+                [
+                    'name'  => __( 'Source', 'wedocs' ),
+                    'value' => $message->source,
+                ],
+                [
+                    'name'  => __( 'Date', 'wedocs' ),
+                    'value' => $message->submitted_at,
+                ],
+                [
+                    'name'  => __( 'IP Address', 'wedocs' ),
+                    'value' => $message->ip_address,
+                ],
+            ];
+
+            $export_items[] = [
+                'group_id'          => 'wedocs-messages',
+                'group_label'       => __( 'weDocs Messages', 'wedocs' ),
+                'group_description' => __( 'Messages submitted through weDocs contact forms.', 'wedocs' ),
+                'item_id'           => "wedocs-message-{$message->id}",
+                'data'              => $data,
+            ];
+        }
+
+        return [
+            'data' => $export_items,
+            'done' => count( $messages ) < $per_page,
+        ];
+    }
+
+    /**
+     * Erase personal data for the given email address.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @param string $email_address Email address to erase data for.
+     * @param int    $page          Page number for batched erasure.
+     *
+     * @return array
+     */
+    public function erase_messages( $email_address, $page = 1 ) {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wedocs_messages';
+
+        // Check if table exists.
+        $table_exists = $wpdb->get_var(
+            $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+        );
+
+        if ( ! $table_exists ) {
+            return [
+                'items_removed'  => 0,
+                'items_retained' => 0,
+                'messages'       => [],
+                'done'           => true,
+            ];
+        }
+
+        $deleted = $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM $table_name WHERE email = %s LIMIT 1000",
+                $email_address
+            )
+        );
+
+        $items_removed = $deleted ? $deleted : 0;
+
+        // Check if there are more to delete.
+        $remaining = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table_name WHERE email = %s",
+                $email_address
+            )
+        );
+
+        return [
+            'items_removed'  => $items_removed,
+            'items_retained' => 0,
+            'messages'       => [],
+            'done'           => (int) $remaining === 0,
+        ];
+    }
+}

--- a/includes/Upgrader/Upgrades/Upgrades.php
+++ b/includes/Upgrader/Upgrades/Upgrades.php
@@ -14,6 +14,7 @@ class Upgrades {
     public $class_list = array(
         '2.0.2'  => V_2_0_2::class,
         '2.1.17' => V_2_1_17::class,
+        '2.2.0'  => V_2_2_0::class,
     );
 
     /**

--- a/includes/Upgrader/Upgrades/V_2_2_0.php
+++ b/includes/Upgrader/Upgrades/V_2_2_0.php
@@ -1,0 +1,36 @@
+<?php
+// DESCRIPTION: Upgrade handler for version 2.2.0.
+// Creates the wedocs_messages table for persistent message storage.
+
+namespace WeDevs\WeDocs\Upgrader\Upgrades;
+
+use WeDevs\WeDocs\Upgrader\Abstracts\UpgradeHandler;
+
+/**
+ * Upgrade handler for version 2.2.0.
+ *
+ * Creates the messages table for storing contact form and widget submissions.
+ */
+class V_2_2_0 extends UpgradeHandler {
+
+    /**
+     * Upgrade version.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @var string
+     */
+    protected $version = '2.2.0';
+
+    /**
+     * Upgrade necessary data in database.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @return void
+     */
+    public function handle_upgrade() {
+        wedocs_create_messages_table();
+        wedocs_add_messages_delete_after_column();
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1182,3 +1182,196 @@ function use_wedocs_legacy_template(){
 
     return false;
 }
+
+/**
+ * Create the wedocs_messages database table.
+ *
+ * @since WEDOCS_SINCE
+ *
+ * @return void
+ */
+function wedocs_create_messages_table() {
+    global $wpdb;
+
+    $table_name      = $wpdb->prefix . 'wedocs_messages';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        name varchar(255) NOT NULL DEFAULT '',
+        email varchar(255) NOT NULL DEFAULT '',
+        subject varchar(255) NOT NULL DEFAULT '',
+        message longtext NOT NULL,
+        doc_id bigint(20) unsigned NOT NULL DEFAULT 0,
+        recipients text NOT NULL,
+        source varchar(20) NOT NULL DEFAULT 'modal',
+        ip_address varchar(45) NOT NULL DEFAULT '',
+        attachment_url text NOT NULL,
+        submitted_at datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+        delete_after datetime DEFAULT NULL,
+        PRIMARY KEY  (id),
+        KEY doc_id (doc_id),
+        KEY submitted_at (submitted_at),
+        KEY delete_after (delete_after)
+    ) $charset_collate;";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+}
+
+/**
+ * Add the delete_after column to the wedocs_messages table if it doesn't exist.
+ * Used for GDPR data retention auto-deletion.
+ *
+ * @since WEDOCS_SINCE
+ *
+ * @return void
+ */
+function wedocs_add_messages_delete_after_column() {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . 'wedocs_messages';
+
+    // Check if table exists first.
+    $table_exists = $wpdb->get_var(
+        $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+    );
+
+    if ( ! $table_exists ) {
+        return;
+    }
+
+    // Check if column already exists.
+    $column_exists = $wpdb->get_results(
+        $wpdb->prepare(
+            "SHOW COLUMNS FROM $table_name LIKE %s",
+            'delete_after'
+        )
+    );
+
+    if ( ! empty( $column_exists ) ) {
+        return;
+    }
+
+    $wpdb->query( "ALTER TABLE $table_name ADD COLUMN delete_after datetime DEFAULT NULL" );
+    $wpdb->query( "ALTER TABLE $table_name ADD INDEX delete_after (delete_after)" );
+}
+
+/**
+ * Store a submitted message in the database.
+ *
+ * @since WEDOCS_SINCE
+ *
+ * @param array $data Message data with keys: name, email, subject, message, doc_id, recipients, source, attachment_url.
+ *
+ * @return int|false The inserted row ID on success, false on failure.
+ */
+function wedocs_store_message( $data ) {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . 'wedocs_messages';
+
+    // Skip storage if the messages table hasn't been created yet.
+    $table_exists = $wpdb->get_var(
+        $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+    );
+
+    if ( ! $table_exists ) {
+        return false;
+    }
+
+    $recipients = isset( $data['recipients'] ) ? $data['recipients'] : '';
+    if ( is_array( $recipients ) ) {
+        $recipients = implode( ', ', $recipients );
+    }
+
+    // Calculate delete_after based on GDPR retention settings.
+    $delete_after = null;
+    $gdpr_settings = wedocs_get_option( 'gdpr', 'wedocs_settings', [] );
+
+    if ( ! empty( $gdpr_settings['enabled'] ) && $gdpr_settings['enabled'] === 'on'
+        && ! empty( $gdpr_settings['retention'] ) && $gdpr_settings['retention'] !== 'manual'
+    ) {
+        $retention_days = intval( $gdpr_settings['retention'] );
+        $delete_after   = gmdate( 'Y-m-d H:i:s', strtotime( current_time( 'mysql' ) . " +{$retention_days} days" ) );
+    }
+
+    $insert_data = [
+        'name'           => isset( $data['name'] ) ? $data['name'] : '',
+        'email'          => isset( $data['email'] ) ? $data['email'] : '',
+        'subject'        => isset( $data['subject'] ) ? $data['subject'] : '',
+        'message'        => isset( $data['message'] ) ? $data['message'] : '',
+        'doc_id'         => isset( $data['doc_id'] ) ? intval( $data['doc_id'] ) : 0,
+        'recipients'     => $recipients,
+        'source'         => isset( $data['source'] ) ? $data['source'] : 'modal',
+        'ip_address'     => wedocs_get_ip_address(),
+        'attachment_url' => isset( $data['attachment_url'] ) ? $data['attachment_url'] : '',
+        'submitted_at'   => current_time( 'mysql' ),
+    ];
+
+    $format = [ '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s' ];
+
+    if ( $delete_after ) {
+        $insert_data['delete_after'] = $delete_after;
+        $format[] = '%s';
+    }
+
+    $inserted = $wpdb->insert( $table_name, $insert_data, $format );
+
+    if ( $inserted ) {
+        return $wpdb->insert_id;
+    }
+
+    return false;
+}
+
+add_action( 'wedocs_before_send_contact_email', 'wedocs_store_message' );
+
+/**
+ * Delete messages that have passed their retention period.
+ * Runs via WP-Cron daily.
+ *
+ * @since WEDOCS_SINCE
+ *
+ * @return void
+ */
+function wedocs_cleanup_expired_messages() {
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . 'wedocs_messages';
+
+    // Check if table exists first.
+    $table_exists = $wpdb->get_var(
+        $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+    );
+
+    if ( ! $table_exists ) {
+        return;
+    }
+
+    $wpdb->query(
+        $wpdb->prepare(
+            "DELETE FROM $table_name WHERE delete_after IS NOT NULL AND delete_after < %s LIMIT 1000",
+            current_time( 'mysql' )
+        )
+    );
+}
+
+/**
+ * Get GDPR settings with resolved page URLs for frontend use.
+ *
+ * @since WEDOCS_SINCE
+ *
+ * @return array
+ */
+function wedocs_get_gdpr_frontend_settings() {
+    $gdpr = wedocs_get_option( 'gdpr', 'wedocs_settings', [] );
+
+    $privacy_page_id = ! empty( $gdpr['privacy_policy_page'] ) ? intval( $gdpr['privacy_policy_page'] ) : 0;
+    $request_page_id = ! empty( $gdpr['data_request_page'] ) ? intval( $gdpr['data_request_page'] ) : 0;
+
+    $gdpr['privacy_policy_url'] = $privacy_page_id ? get_permalink( $privacy_page_id ) : '';
+    $gdpr['data_request_url']   = $request_page_id ? get_permalink( $request_page_id ) : '';
+
+    return $gdpr;
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,6 +11,7 @@ import Documentations from './Documentations';
 import Migrate from './Migrations';
 import NotFound from './NotFound';
 import PermissionSettingsDemo from './PermissionSettingsDemo';
+import Messages from './Messages';
 
 const App = () => {
   let routes = [
@@ -20,6 +21,7 @@ const App = () => {
     { path: 'settings/:panel', component: SettingsPage },
     { path: 'section/:id', component: ListingPage },
     { path: 'migrate', component: Migrate },
+    { path: 'messages', component: Messages },
   ];
 
   routes = wp.hooks.applyFilters('wedocs_register_menu_routes', routes);

--- a/src/components/Messages/MessageDetail.js
+++ b/src/components/Messages/MessageDetail.js
@@ -1,0 +1,188 @@
+// DESCRIPTION: Modal component for displaying full details of a single message.
+// Shows all message fields including name, email, subject, body, and metadata.
+
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { Dialog, Transition } from '@headlessui/react';
+
+const MessageDetail = ( { message, isOpen, onClose } ) => {
+	if ( ! message ) {
+		return null;
+	}
+
+	const formatDate = ( dateString ) => {
+		const date = new Date( dateString );
+		return date.toLocaleString();
+	};
+
+	return (
+		<Transition appear show={ isOpen } as={ Fragment }>
+			<Dialog
+				as="div"
+				className="wedocs-document relative z-[9999]"
+				onClose={ onClose }
+			>
+				<Transition.Child
+					as={ Fragment }
+					enter="ease-out duration-300"
+					enterFrom="opacity-0"
+					enterTo="opacity-100"
+					leave="ease-in duration-200"
+					leaveFrom="opacity-100"
+					leaveTo="opacity-0"
+				>
+					<div className="fixed inset-0 bg-black bg-opacity-25 z-[50]" />
+				</Transition.Child>
+
+				<div className="fixed inset-0 overflow-y-auto z-[100]">
+					<div className="flex min-h-full items-center justify-center p-4">
+						<Transition.Child
+							as={ Fragment }
+							enter="ease-out duration-300"
+							enterFrom="opacity-0 scale-95"
+							enterTo="opacity-100 scale-100"
+							leave="ease-in duration-200"
+							leaveFrom="opacity-100 scale-100"
+							leaveTo="opacity-0 scale-95"
+						>
+							<Dialog.Panel className="w-[640px] transform overflow-hidden rounded-2xl bg-white py-6 px-9 align-middle shadow-xl transition-all">
+								<Dialog.Title
+									as="h3"
+									className="text-lg font-medium text-gray-900 mb-4 flex items-center justify-between"
+								>
+									<span>{ __( 'Message Details', 'wedocs' ) }</span>
+									<button
+										onClick={ onClose }
+										className="text-gray-400 hover:text-gray-600 cursor-pointer"
+									>
+										<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={ 2 } stroke="currentColor" className="w-5 h-5">
+											<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+										</svg>
+									</button>
+								</Dialog.Title>
+
+								<div className="space-y-4">
+									<div className="grid grid-cols-2 gap-4">
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Name', 'wedocs' ) }
+											</label>
+											<p className="text-sm text-gray-900">{ message.name }</p>
+										</div>
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Email', 'wedocs' ) }
+											</label>
+											<p className="text-sm text-gray-900">
+												<a href={ `mailto:${ message.email }` } className="text-indigo-600 hover:text-indigo-800">
+													{ message.email }
+												</a>
+											</p>
+										</div>
+									</div>
+
+									{ message.subject && (
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Subject', 'wedocs' ) }
+											</label>
+											<p className="text-sm text-gray-900">{ message.subject }</p>
+										</div>
+									) }
+
+									<div>
+										<label className="block text-sm font-medium text-gray-500 mb-1">
+											{ __( 'Message', 'wedocs' ) }
+										</label>
+										<p className="text-sm text-gray-900 whitespace-pre-wrap bg-gray-50 rounded-md p-3">
+											{ message.message }
+										</p>
+									</div>
+
+									<div className="grid grid-cols-2 gap-4 pt-2 border-t border-gray-200">
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Source', 'wedocs' ) }
+											</label>
+											<span className={ `inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${ message.source === 'widget' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800' }` }>
+												{ message.source === 'widget' ? __( 'Widget', 'wedocs' ) : __( 'Modal', 'wedocs' ) }
+											</span>
+										</div>
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Date', 'wedocs' ) }
+											</label>
+											<p className="text-sm text-gray-900">{ formatDate( message.submitted_at ) }</p>
+										</div>
+									</div>
+
+									<div className="grid grid-cols-2 gap-4">
+										{ message.recipients && (
+											<div>
+												<label className="block text-sm font-medium text-gray-500 mb-1">
+													{ __( 'Recipients', 'wedocs' ) }
+												</label>
+												<p className="text-sm text-gray-900">{ message.recipients }</p>
+											</div>
+										) }
+										{ message.ip_address && (
+											<div>
+												<label className="block text-sm font-medium text-gray-500 mb-1">
+													{ __( 'IP Address', 'wedocs' ) }
+												</label>
+												<p className="text-sm text-gray-900">{ message.ip_address }</p>
+											</div>
+										) }
+									</div>
+
+									{ parseInt( message.doc_id ) > 0 && (
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Related Doc', 'wedocs' ) }
+											</label>
+											<a
+												href={ `${ window.weDocsAdminVars?.adminUrl }post.php?action=edit&post=${ message.doc_id }` }
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-sm text-indigo-600 hover:text-indigo-800"
+											>
+												{ __( 'View Doc #', 'wedocs' ) }{ message.doc_id }
+											</a>
+										</div>
+									) }
+
+									{ message.attachment_url && (
+										<div>
+											<label className="block text-sm font-medium text-gray-500 mb-1">
+												{ __( 'Attachment', 'wedocs' ) }
+											</label>
+											<a
+												href={ message.attachment_url }
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-sm text-indigo-600 hover:text-indigo-800"
+											>
+												{ __( 'View Attachment', 'wedocs' ) }
+											</a>
+										</div>
+									) }
+								</div>
+
+								<div className="mt-6 text-right">
+									<button
+										className="bg-white hover:bg-gray-200 text-gray-700 font-medium text-sm py-2 px-5 border border-gray-300 rounded-md cursor-pointer"
+										onClick={ onClose }
+									>
+										{ __( 'Close', 'wedocs' ) }
+									</button>
+								</div>
+							</Dialog.Panel>
+						</Transition.Child>
+					</div>
+				</div>
+			</Dialog>
+		</Transition>
+	);
+};
+
+export default MessageDetail;

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -1,0 +1,347 @@
+// DESCRIPTION: Admin page component for listing and managing stored messages.
+// Provides a paginated table view with search, detail view, and delete actions.
+
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, Fragment } from '@wordpress/element';
+import { useSelect, dispatch } from '@wordpress/data';
+import { Dialog, Transition } from '@headlessui/react';
+import { MESSAGES_STORE } from '../../data/messages';
+import MessageDetail from './MessageDetail';
+import Swal from 'sweetalert2';
+
+const Messages = () => {
+	const messages = useSelect(
+		( select ) => select( MESSAGES_STORE ).getMessages(),
+		[]
+	);
+
+	const loading = useSelect(
+		( select ) => select( MESSAGES_STORE ).getMessagesLoading(),
+		[]
+	);
+
+	const meta = useSelect(
+		( select ) => select( MESSAGES_STORE ).getMessagesMeta(),
+		[]
+	);
+
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+	const [ searchValue, setSearchValue ] = useState( '' );
+	const [ sourceFilter, setSourceFilter ] = useState( '' );
+	const [ selectedMessage, setSelectedMessage ] = useState( null );
+	const [ deleteModalOpen, setDeleteModalOpen ] = useState( false );
+	const [ messageToDelete, setMessageToDelete ] = useState( null );
+	const [ apiError, setApiError ] = useState( null );
+	const perPage = 20;
+
+	useEffect( () => {
+		setApiError( null );
+		dispatch( MESSAGES_STORE )
+			.fetchMessages( currentPage, perPage, searchValue, sourceFilter )
+			.catch( ( err ) => {
+				dispatch( MESSAGES_STORE ).setMessagesLoading( false );
+				setApiError( err.message || __( 'Failed to load messages.', 'wedocs' ) );
+			} );
+	}, [ currentPage, sourceFilter ] );
+
+	const handleSearch = ( event ) => {
+		event.preventDefault();
+		setCurrentPage( 1 );
+		setApiError( null );
+		dispatch( MESSAGES_STORE )
+			.fetchMessages( 1, perPage, searchValue, sourceFilter )
+			.catch( ( err ) => {
+				console.error( 'weDocs Messages: Failed to search messages', err );
+				dispatch( MESSAGES_STORE ).setMessagesLoading( false );
+				setApiError( err.message || __( 'Failed to load messages.', 'wedocs' ) );
+			} );
+	};
+
+	const handleDelete = () => {
+		if ( ! messageToDelete ) {
+			return;
+		}
+
+		dispatch( MESSAGES_STORE )
+			.deleteMessage( messageToDelete.id )
+			.then( () => {
+				setDeleteModalOpen( false );
+				setMessageToDelete( null );
+				Swal.fire( {
+					title: __( 'Deleted', 'wedocs' ),
+					text: __( 'Message deleted successfully.', 'wedocs' ),
+					icon: 'success',
+					toast: true,
+					position: 'bottom-end',
+					showConfirmButton: false,
+					timer: 3000,
+				} );
+			} )
+			.catch( ( err ) => {
+				Swal.fire( {
+					title: __( 'Error', 'wedocs' ),
+					text: err.message,
+					icon: 'error',
+					toast: true,
+					position: 'bottom-end',
+					showConfirmButton: false,
+					timer: 3000,
+				} );
+			} );
+	};
+
+	const openDeleteModal = ( message ) => {
+		setMessageToDelete( message );
+		setDeleteModalOpen( true );
+	};
+
+	const formatDate = ( dateString ) => {
+		const date = new Date( dateString );
+		return date.toLocaleDateString();
+	};
+
+	const truncateText = ( text, maxLength = 60 ) => {
+		if ( ! text ) {
+			return '';
+		}
+		return text.length > maxLength ? text.substring( 0, maxLength ) + '...' : text;
+	};
+
+	return (
+		<div className="wedocs-messages-page p-8">
+			<div className="mb-6 flex items-center justify-between">
+				<h1 className="text-2xl font-bold text-gray-900">
+					{ __( 'Messages', 'wedocs' ) }
+				</h1>
+				<span className="text-sm text-gray-500">
+					{ meta.total > 0 && (
+						<>{ meta.total } { meta.total === 1 ? __( 'message', 'wedocs' ) : __( 'messages', 'wedocs' ) }</>
+					) }
+				</span>
+			</div>
+
+			{ /* Search and filters */ }
+			<div className="mb-4 flex items-center gap-3">
+				<form onSubmit={ handleSearch } className="flex items-center gap-2">
+					<input
+						type="text"
+						placeholder={ __( 'Search messages...', 'wedocs' ) }
+						value={ searchValue }
+						onChange={ ( e ) => setSearchValue( e.target.value ) }
+						className="!border !border-gray-300 !rounded-md !px-3 !py-2 text-sm text-gray-700 focus:ring-indigo-500 focus:border-indigo-500"
+					/>
+					<button
+						type="submit"
+						className="bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium py-2 px-4 rounded-md cursor-pointer"
+					>
+						{ __( 'Search', 'wedocs' ) }
+					</button>
+				</form>
+				<select
+					value={ sourceFilter }
+					onChange={ ( e ) => {
+						setSourceFilter( e.target.value );
+						setCurrentPage( 1 );
+					} }
+					className="!border !border-gray-300 !rounded-md !px-3 !py-2 text-sm text-gray-700 w-[10rem]"
+				>
+					<option value="">{ __( 'All Sources', 'wedocs' ) }</option>
+					<option value="modal">{ __( 'Modal', 'wedocs' ) }</option>
+					<option value="widget">{ __( 'Widget', 'wedocs' ) }</option>
+				</select>
+			</div>
+
+			{ /* Error message */ }
+			{ apiError && (
+				<div className="mb-4 bg-red-50 border border-red-200 rounded-md p-4">
+					<div className="flex items-start">
+						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={ 1.5 } stroke="currentColor" className="w-5 h-5 text-red-500 mt-0.5 mr-3 flex-shrink-0">
+							<path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+						</svg>
+						<p className="text-sm text-red-700">{ apiError }</p>
+					</div>
+				</div>
+			) }
+
+			{ /* Messages table */ }
+			<div className="bg-white rounded-lg shadow overflow-hidden">
+				{ loading ? (
+					<div className="p-8 text-center text-gray-500">
+						{ __( 'Loading messages...', 'wedocs' ) }
+					</div>
+				) : messages.length === 0 ? (
+					<div className="p-8 text-center text-gray-500">
+						{ __( 'No messages found.', 'wedocs' ) }
+					</div>
+				) : (
+					<table className="min-w-full divide-y divide-gray-200">
+						<thead className="bg-gray-50">
+							<tr>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Name', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Email', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Subject', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Message', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Source', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Date', 'wedocs' ) }
+								</th>
+								<th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+									{ __( 'Actions', 'wedocs' ) }
+								</th>
+							</tr>
+						</thead>
+						<tbody className="bg-white divide-y divide-gray-200">
+							{ messages.map( ( message ) => (
+								<tr
+									key={ message.id }
+									className="hover:bg-gray-50 cursor-pointer"
+									onClick={ () => setSelectedMessage( message ) }
+								>
+									<td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+										{ message.name }
+									</td>
+									<td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+										{ message.email }
+									</td>
+									<td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+										{ truncateText( message.subject, 30 ) || '—' }
+									</td>
+									<td className="px-6 py-4 text-sm text-gray-500 max-w-xs">
+										{ truncateText( message.message ) }
+									</td>
+									<td className="px-6 py-4 whitespace-nowrap">
+										<span className={ `inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${ message.source === 'widget' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800' }` }>
+											{ message.source === 'widget' ? __( 'Widget', 'wedocs' ) : __( 'Modal', 'wedocs' ) }
+										</span>
+									</td>
+									<td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+										{ formatDate( message.submitted_at ) }
+									</td>
+									<td className="px-6 py-4 whitespace-nowrap text-right text-sm">
+										<button
+											onClick={ ( e ) => {
+												e.stopPropagation();
+												openDeleteModal( message );
+											} }
+											className="text-red-600 hover:text-red-800 cursor-pointer"
+											title={ __( 'Delete', 'wedocs' ) }
+										>
+											<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={ 1.5 } stroke="currentColor" className="w-5 h-5">
+												<path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+											</svg>
+										</button>
+									</td>
+								</tr>
+							) ) }
+						</tbody>
+					</table>
+				) }
+			</div>
+
+			{ /* Pagination */ }
+			{ meta.totalPages > 1 && (
+				<div className="mt-4 flex items-center justify-between">
+					<p className="text-sm text-gray-500">
+						{ __( 'Page', 'wedocs' ) } { currentPage } { __( 'of', 'wedocs' ) } { meta.totalPages }
+					</p>
+					<div className="flex gap-2">
+						<button
+							disabled={ currentPage <= 1 }
+							onClick={ () => setCurrentPage( currentPage - 1 ) }
+							className="bg-white hover:bg-gray-100 text-gray-700 text-sm font-medium py-2 px-4 border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+						>
+							{ __( 'Previous', 'wedocs' ) }
+						</button>
+						<button
+							disabled={ currentPage >= meta.totalPages }
+							onClick={ () => setCurrentPage( currentPage + 1 ) }
+							className="bg-white hover:bg-gray-100 text-gray-700 text-sm font-medium py-2 px-4 border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+						>
+							{ __( 'Next', 'wedocs' ) }
+						</button>
+					</div>
+				</div>
+			) }
+
+			{ /* Message detail modal */ }
+			<MessageDetail
+				message={ selectedMessage }
+				isOpen={ !! selectedMessage }
+				onClose={ () => setSelectedMessage( null ) }
+			/>
+
+			{ /* Delete confirmation modal */ }
+			<Transition appear show={ deleteModalOpen } as={ Fragment }>
+				<Dialog
+					as="div"
+					className="wedocs-document relative z-[9999]"
+					onClose={ () => setDeleteModalOpen( false ) }
+				>
+					<Transition.Child
+						as={ Fragment }
+						enter="ease-out duration-300"
+						enterFrom="opacity-0"
+						enterTo="opacity-100"
+						leave="ease-in duration-200"
+						leaveFrom="opacity-100"
+						leaveTo="opacity-0"
+					>
+						<div className="fixed inset-0 bg-black bg-opacity-25 z-[50]" />
+					</Transition.Child>
+
+					<div className="fixed inset-0 overflow-y-auto z-[100]">
+						<div className="flex min-h-full items-center justify-center p-4">
+							<Transition.Child
+								as={ Fragment }
+								enter="ease-out duration-300"
+								enterFrom="opacity-0 scale-95"
+								enterTo="opacity-100 scale-100"
+								leave="ease-in duration-200"
+								leaveFrom="opacity-100 scale-100"
+								leaveTo="opacity-0 scale-95"
+							>
+								<Dialog.Panel className="w-[440px] transform overflow-hidden rounded-2xl bg-white py-6 px-9 align-middle shadow-xl transition-all">
+									<Dialog.Title
+										as="h3"
+										className="text-lg font-medium text-gray-900 mb-2"
+									>
+										{ __( 'Delete Message', 'wedocs' ) }
+									</Dialog.Title>
+									<p className="text-gray-500 text-sm mb-6">
+										{ __( 'Are you sure you want to delete this message? This action cannot be undone.', 'wedocs' ) }
+									</p>
+									<div className="flex justify-end gap-3">
+										<button
+											className="bg-white hover:bg-gray-200 text-gray-700 font-medium text-sm py-2 px-5 border border-gray-300 rounded-md cursor-pointer"
+											onClick={ () => setDeleteModalOpen( false ) }
+										>
+											{ __( 'Cancel', 'wedocs' ) }
+										</button>
+										<button
+											className="bg-red-600 hover:bg-red-700 text-white font-medium text-sm py-2 px-5 rounded-md cursor-pointer"
+											onClick={ handleDelete }
+										>
+											{ __( 'Delete', 'wedocs' ) }
+										</button>
+									</div>
+								</Dialog.Panel>
+							</Transition.Child>
+						</div>
+					</div>
+				</Dialog>
+			</Transition>
+		</div>
+	);
+};
+
+export default Messages;

--- a/src/components/Settings/GdprSettings.js
+++ b/src/components/Settings/GdprSettings.js
@@ -1,0 +1,397 @@
+// DESCRIPTION: GDPR Compliance settings tab component.
+// Provides admin controls for enabling GDPR features, data retention, and consent configuration.
+
+import { __ } from '@wordpress/i18n';
+import Switcher from '../Switcher';
+import { useEffect, useState, Fragment } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Listbox, Transition } from '@headlessui/react';
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
+import docsStore from '../../data/docs';
+
+const GdprSettings = ( {
+	settingsData,
+	gdprSettingsData,
+	setSettings,
+} ) => {
+	const [ gdprSettings, setGdprSettings ] = useState( {
+		...gdprSettingsData,
+	} );
+
+	const [ validationError, setValidationError ] = useState( '' );
+
+	const pages = useSelect( ( select ) => select( docsStore ).getPages(), [] );
+	const [ pageOptions, setPageOptions ] = useState( [] );
+	const [ selectedPolicyPage, setSelectedPolicyPage ] = useState( {} );
+	const [ selectedRequestPage, setSelectedRequestPage ] = useState( {} );
+
+	useEffect( () => {
+		setGdprSettings( { ...gdprSettingsData } );
+	}, [ gdprSettingsData ] );
+
+	useEffect( () => {
+		const options = pages?.map( ( page ) => ( {
+			id: page?.id,
+			name: page?.title?.rendered,
+		} ) );
+
+		setPageOptions( options || [] );
+
+		if ( gdprSettingsData?.privacy_policy_page ) {
+			const policyPage = options?.find(
+				( page ) => page?.id === parseInt( gdprSettingsData.privacy_policy_page )
+			);
+			if ( policyPage ) {
+				setSelectedPolicyPage( policyPage );
+			}
+		}
+
+		if ( gdprSettingsData?.data_request_page ) {
+			const requestPage = options?.find(
+				( page ) => page?.id === parseInt( gdprSettingsData.data_request_page )
+			);
+			if ( requestPage ) {
+				setSelectedRequestPage( requestPage );
+			}
+		}
+	}, [ pages, gdprSettingsData?.privacy_policy_page, gdprSettingsData?.data_request_page ] );
+
+	const handleFieldChange = ( field, value ) => {
+		setValidationError( '' );
+		setSettings( {
+			...settingsData,
+			gdpr: { ...gdprSettingsData, [ field ]: value },
+		} );
+	};
+
+	const handlePolicyPageChange = ( page ) => {
+		setSelectedPolicyPage( page );
+		setValidationError( '' );
+		setSettings( {
+			...settingsData,
+			gdpr: { ...gdprSettingsData, privacy_policy_page: page?.id },
+		} );
+	};
+
+	const handleRequestPageChange = ( page ) => {
+		setSelectedRequestPage( page );
+		setSettings( {
+			...settingsData,
+			gdpr: { ...gdprSettingsData, data_request_page: page?.id },
+		} );
+	};
+
+	const isEnabled = gdprSettings?.enabled === 'on';
+
+	return (
+		<section>
+			<div className="shadow sm:rounded-md">
+				<div className="bg-white sm:rounded-md min-h-[500px]">
+					<div className="section-heading py-4 px-8 sm:px-8 sm:py-4">
+						<h2 className="text-gray-900 font-medium text-lg">
+							{ __( 'GDPR Compliance', 'wedocs' ) }
+						</h2>
+					</div>
+					<hr className="h-px !bg-gray-200 border-0 dark:!bg-gray-200" />
+					<div className="pt-6 pb-20 px-8 grid grid-cols-4 gap-5">
+
+						{ /* Master toggle */ }
+						<div className="col-span-4">
+							<div className="settings-content flex items-center justify-between">
+								<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+									<label className="block text-sm font-medium text-gray-600">
+										{ __( 'Enable GDPR Compliance', 'wedocs' ) }
+									</label>
+									<div
+										className="tooltip cursor-pointer ml-2 z-[9999]"
+										data-tip={ __(
+											'Important: You are responsible for deleting user data from external systems (if weDocs form data is synced to CRMs/email platforms) to remain GDPR compliant.',
+											'wedocs'
+										) }
+									>
+										<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" strokeWidth={ 1.5 } stroke="#9CA3AF" className="w-[18px] h-[18px]">
+											<path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+										</svg>
+									</div>
+								</div>
+								<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2 flex items-center">
+									<Switcher
+										name="enabled"
+										settingsPanel={ gdprSettings }
+										settingsData={ settingsData }
+										setSettings={ setSettings }
+										panelName="gdpr"
+										isEnabled={ isEnabled }
+									/>
+								</div>
+							</div>
+							<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+								<p className="text-sm text-[#6B7280]">
+									{ __( 'Master toggle for all GDPR settings in the contact modal and messaging widget.', 'wedocs' ) }
+								</p>
+							</div>
+						</div>
+
+						{ isEnabled && (
+							<>
+								{ /* Data Retention */ }
+								<div className="col-span-4">
+									<div className="settings-content flex items-center justify-between">
+										<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+											<label className="block text-sm font-medium text-gray-600">
+												{ __( 'Data Retention', 'wedocs' ) }
+											</label>
+										</div>
+										<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2">
+											<select
+												value={ gdprSettings?.retention || 'manual' }
+												onChange={ ( e ) => handleFieldChange( 'retention', e.target.value ) }
+												className="!border !border-gray-300 !rounded-md !px-3 !py-2 text-sm text-gray-700 w-full"
+											>
+												<option value="manual">{ __( 'Manual deletion only', 'wedocs' ) }</option>
+												<option value="30">{ __( 'Auto-delete after 30 days', 'wedocs' ) }</option>
+												<option value="60">{ __( 'Auto-delete after 60 days', 'wedocs' ) }</option>
+												<option value="90">{ __( 'Auto-delete after 90 days', 'wedocs' ) }</option>
+											</select>
+										</div>
+									</div>
+									<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+										<p className="text-sm text-[#6B7280]">
+											{ __( 'How long to retain stored messages before automatic deletion.', 'wedocs' ) }
+										</p>
+									</div>
+								</div>
+
+								{ /* Enable GDPR in Contact Modal */ }
+								<div className="col-span-4">
+									<div className="settings-content flex items-center justify-between">
+										<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+											<label className="block text-sm font-medium text-gray-600">
+												{ __( 'Enable GDPR in Contact Modal', 'wedocs' ) }
+											</label>
+										</div>
+										<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2 flex items-center">
+											<Switcher
+												name="modal_enabled"
+												settingsPanel={ gdprSettings }
+												settingsData={ settingsData }
+												setSettings={ setSettings }
+												panelName="gdpr"
+												isEnabled={ gdprSettings?.modal_enabled === 'on' }
+											/>
+										</div>
+									</div>
+									<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+										<p className="text-sm text-[#6B7280]">
+											{ __( 'Show consent checkbox on the "How can we help?" contact form.', 'wedocs' ) }
+										</p>
+									</div>
+								</div>
+
+								{ /* Enable GDPR in Messaging (Pro only) */ }
+								{ window.weDocsAdminVars?.pro_active && (
+									<div className="col-span-4">
+										<div className="settings-content flex items-center justify-between">
+											<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+												<label className="block text-sm font-medium text-gray-600">
+													{ __( 'Enable GDPR in Messaging', 'wedocs' ) }
+												</label>
+											</div>
+											<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2 flex items-center">
+												<Switcher
+													name="messaging_enabled"
+													settingsPanel={ gdprSettings }
+													settingsData={ settingsData }
+													setSettings={ setSettings }
+													panelName="gdpr"
+													isEnabled={ gdprSettings?.messaging_enabled === 'on' }
+												/>
+											</div>
+										</div>
+										<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+											<p className="text-sm text-[#6B7280]">
+												{ __( 'Show consent checkbox on the messaging widget contact form.', 'wedocs' ) }
+											</p>
+										</div>
+									</div>
+								) }
+
+								{ /* Consent Checkbox Text */ }
+								<div className="col-span-4">
+									<div className="settings-content flex items-center justify-between">
+										<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+											<label className="block text-sm font-medium text-gray-600">
+												{ __( 'Consent Checkbox Text', 'wedocs' ) }
+											</label>
+										</div>
+										<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2">
+											<textarea
+												rows="3"
+												value={ gdprSettings?.consent_text || '' }
+												onChange={ ( e ) => handleFieldChange( 'consent_text', e.target.value ) }
+												className="!border !border-gray-300 !rounded-md !px-3 !py-2 text-sm text-gray-700 w-full"
+											/>
+										</div>
+									</div>
+									<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+										<p className="text-sm text-[#6B7280]">
+											{ __( 'Available tokens: {privacy_policy}, {request_data}', 'wedocs' ) }
+										</p>
+									</div>
+								</div>
+
+								{ /* Privacy Policy Page */ }
+								<div className="col-span-4">
+									<div className="settings-content flex items-center justify-between">
+										<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+											<label className="block text-sm font-medium text-gray-600">
+												{ __( 'Privacy Policy Page', 'wedocs' ) }
+												<span className="text-red-500 ml-1">*</span>
+											</label>
+										</div>
+										<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2">
+											<div className="relative">
+												{ pageOptions.length > 0 ? (
+													<Listbox value={ selectedPolicyPage } onChange={ handlePolicyPageChange }>
+														<div className="relative mt-1">
+															<Listbox.Button className="relative w-full cursor-pointer rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
+																<span className="block truncate">
+																	{ selectedPolicyPage?.name || __( 'Select a page', 'wedocs' ) }
+																</span>
+																<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+																	<ChevronDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+																</span>
+															</Listbox.Button>
+															<Transition
+																as={ Fragment }
+																leave="transition ease-in duration-100"
+																leaveFrom="opacity-100"
+																leaveTo="opacity-0"
+															>
+																<Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+																	{ pageOptions.map( ( page ) => (
+																		<Listbox.Option
+																			key={ page.id }
+																			className={ ( { active } ) =>
+																				`cursor-pointer relative select-none py-2 pl-3 pr-9 ${ active ? 'text-white bg-indigo-600' : 'text-gray-900' }`
+																			}
+																			value={ page }
+																		>
+																			{ ( { selected, active } ) => (
+																				<>
+																					<span className={ `block truncate ${ selected ? 'font-semibold' : 'font-normal' }` }>
+																						{ page.name }
+																					</span>
+																					{ selected && (
+																						<span className={ `absolute inset-y-0 right-0 flex items-center pr-4 ${ active ? 'text-white' : 'text-indigo-600' }` }>
+																							<CheckIcon className="h-5 w-5" aria-hidden="true" />
+																						</span>
+																					) }
+																				</>
+																			) }
+																		</Listbox.Option>
+																	) ) }
+																</Listbox.Options>
+															</Transition>
+														</div>
+													</Listbox>
+												) : (
+													<input
+														className="relative !w-full !rounded-md border !border-gray-300 bg-white !py-2 !pl-3 !pr-10 text-left shadow-sm sm:text-sm"
+														placeholder={ __( 'Loading pages...', 'wedocs' ) }
+														disabled
+													/>
+												) }
+											</div>
+											{ validationError && (
+												<p className="text-sm text-red-600 mt-1">{ validationError }</p>
+											) }
+										</div>
+									</div>
+									<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+										<p className="text-sm text-[#6B7280]">
+											{ __( 'Select the page containing your privacy policy.', 'wedocs' ) }
+										</p>
+									</div>
+								</div>
+
+								{ /* Data Access Request Page */ }
+								<div className="col-span-4">
+									<div className="settings-content flex items-center justify-between">
+										<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
+											<label className="block text-sm font-medium text-gray-600">
+												{ __( 'Data Access Request Page', 'wedocs' ) }
+											</label>
+										</div>
+										<div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2">
+											<div className="relative">
+												{ pageOptions.length > 0 ? (
+													<Listbox value={ selectedRequestPage } onChange={ handleRequestPageChange }>
+														<div className="relative mt-1">
+															<Listbox.Button className="relative w-full cursor-pointer rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
+																<span className="block truncate">
+																	{ selectedRequestPage?.name || __( 'Select a page', 'wedocs' ) }
+																</span>
+																<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+																	<ChevronDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+																</span>
+															</Listbox.Button>
+															<Transition
+																as={ Fragment }
+																leave="transition ease-in duration-100"
+																leaveFrom="opacity-100"
+																leaveTo="opacity-0"
+															>
+																<Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+																	{ pageOptions.map( ( page ) => (
+																		<Listbox.Option
+																			key={ page.id }
+																			className={ ( { active } ) =>
+																				`cursor-pointer relative select-none py-2 pl-3 pr-9 ${ active ? 'text-white bg-indigo-600' : 'text-gray-900' }`
+																			}
+																			value={ page }
+																		>
+																			{ ( { selected, active } ) => (
+																				<>
+																					<span className={ `block truncate ${ selected ? 'font-semibold' : 'font-normal' }` }>
+																						{ page.name }
+																					</span>
+																					{ selected && (
+																						<span className={ `absolute inset-y-0 right-0 flex items-center pr-4 ${ active ? 'text-white' : 'text-indigo-600' }` }>
+																							<CheckIcon className="h-5 w-5" aria-hidden="true" />
+																						</span>
+																					) }
+																				</>
+																			) }
+																		</Listbox.Option>
+																	) ) }
+																</Listbox.Options>
+															</Transition>
+														</div>
+													</Listbox>
+												) : (
+													<input
+														className="relative !w-full !rounded-md border !border-gray-300 bg-white !py-2 !pl-3 !pr-10 text-left shadow-sm sm:text-sm"
+														placeholder={ __( 'Loading pages...', 'wedocs' ) }
+														disabled
+													/>
+												) }
+											</div>
+										</div>
+									</div>
+									<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
+										<p className="text-sm text-[#6B7280]">
+											{ __( 'Select the page where users can request access to or deletion of their data.', 'wedocs' ) }
+										</p>
+									</div>
+								</div>
+							</>
+						) }
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+};
+
+export default GdprSettings;

--- a/src/components/Settings/Menu.js
+++ b/src/components/Settings/Menu.js
@@ -23,6 +23,25 @@ const Menu = () => {
         </svg>
       ),
     },
+    gdpr: {
+      text: __( 'GDPR Compliance', 'wedocs' ),
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          stroke="#6b7280"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="-ml-1 mr-4"
+          viewBox="0 0 24 24"
+        >
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+      ),
+    },
     ai: {
       text: __( 'AI Control', 'wedocs' ),
       icon: (

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -5,6 +5,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { dispatch, useSelect } from '@wordpress/data';
 import settingsStore from '../../data/settings';
 import GeneralSettings from './GeneralSettings';
+import GdprSettings from './GdprSettings';
 import AiSettings from './AiSettings';
 import Swal from 'sweetalert2';
 import { __ } from '@wordpress/i18n';
@@ -68,6 +69,12 @@ const SettingsPage = () => {
       index={ selectedIndex }
       settingsData={ docSettings }
       generalSettingsData={ docSettings?.general }
+      setSettings={ setDocSettings }
+    />,
+    <GdprSettings
+      index={ selectedIndex }
+      settingsData={ docSettings }
+      gdprSettingsData={ docSettings?.gdpr }
       setSettings={ setDocSettings }
     />,
     <AiSettings

--- a/src/data/messages/actions.js
+++ b/src/data/messages/actions.js
@@ -1,0 +1,72 @@
+// DESCRIPTION: Redux store actions for the messages data store.
+// Provides synchronous setters and async generators for CRUD operations.
+
+const actions = {
+	setMessages( messages ) {
+		return { type: 'SET_MESSAGES', messages };
+	},
+
+	setMessage( message ) {
+		return { type: 'SET_MESSAGE', message };
+	},
+
+	setMessagesLoading( loading ) {
+		return { type: 'SET_MESSAGES_LOADING', loading };
+	},
+
+	setMessagesMeta( meta ) {
+		return { type: 'SET_MESSAGES_META', meta };
+	},
+
+	removeMessage( messageId ) {
+		return { type: 'REMOVE_MESSAGE', messageId };
+	},
+
+	setMessagesError( error ) {
+		return { type: 'SET_MESSAGES_ERROR', error };
+	},
+
+	fetchFromAPI( path ) {
+		return { type: 'FETCH_FROM_API', path };
+	},
+
+	*fetchMessages( page = 1, perPage = 20, search = '', source = '' ) {
+		yield actions.setMessagesLoading( true );
+
+		let path = `/wp/v2/docs/messages?page=${ page }&per_page=${ perPage }`;
+		if ( search ) {
+			path += `&search=${ encodeURIComponent( search ) }`;
+		}
+		if ( source ) {
+			path += `&source=${ encodeURIComponent( source ) }`;
+		}
+
+		const response = yield actions.fetchFromAPI( path );
+
+		yield actions.setMessages( response.messages );
+		yield actions.setMessagesMeta( {
+			total: response.total,
+			totalPages: response.total_pages,
+		} );
+
+		return actions.setMessagesLoading( false );
+	},
+
+	*fetchMessage( id ) {
+		yield actions.setMessagesLoading( true );
+
+		const path = `/wp/v2/docs/messages/${ id }`;
+		const response = yield actions.fetchFromAPI( path );
+		yield actions.setMessage( response );
+
+		return actions.setMessagesLoading( false );
+	},
+
+	*deleteMessage( messageId ) {
+		const path = `/wp/v2/docs/messages/${ messageId }`;
+		yield { type: 'DELETE_TO_API', path };
+		return actions.removeMessage( messageId );
+	},
+};
+
+export default actions;

--- a/src/data/messages/controls.js
+++ b/src/data/messages/controls.js
@@ -1,0 +1,27 @@
+// DESCRIPTION: API fetch controls for the messages data store.
+// Maps action types to apiFetch calls for REST API communication.
+
+import apiFetch from '@wordpress/api-fetch';
+
+const controls = {
+	FETCH_FROM_API( action ) {
+		return apiFetch( { path: action.path } );
+	},
+
+	UPDATE_TO_API( action ) {
+		return apiFetch( {
+			path: action.path,
+			data: action.data,
+			method: 'POST',
+		} );
+	},
+
+	DELETE_TO_API( action ) {
+		return apiFetch( {
+			path: action.path,
+			method: 'DELETE',
+		} );
+	},
+};
+
+export default controls;

--- a/src/data/messages/index.js
+++ b/src/data/messages/index.js
@@ -1,0 +1,21 @@
+// DESCRIPTION: Messages data store registration.
+// Creates and exports the wedocs/messages Redux store.
+
+import { createReduxStore } from '@wordpress/data';
+import reducer from './reducer';
+import actions from './actions';
+import selectors from './selectors';
+import controls from './controls';
+import resolvers from './resolvers';
+
+export const MESSAGES_STORE = 'wedocs/messages';
+
+const messagesStore = createReduxStore( MESSAGES_STORE, {
+	reducer,
+	selectors,
+	actions,
+	resolvers,
+	controls,
+} );
+
+export default messagesStore;

--- a/src/data/messages/reducer.js
+++ b/src/data/messages/reducer.js
@@ -1,0 +1,61 @@
+// DESCRIPTION: Redux reducer for the messages data store.
+// Manages state for messages list, single message, loading, and pagination meta.
+
+const DEFAULT_STATE = {
+	messages: [],
+	message: null,
+	loading: false,
+	error: null,
+	meta: { total: 0, totalPages: 0 },
+};
+
+const reducer = ( state = DEFAULT_STATE, action ) => {
+	switch ( action.type ) {
+		case 'SET_MESSAGES':
+			return {
+				...state,
+				messages: [ ...action.messages ],
+			};
+
+		case 'SET_MESSAGE':
+			return {
+				...state,
+				message: action.message,
+			};
+
+		case 'SET_MESSAGES_LOADING':
+			return {
+				...state,
+				loading: action.loading,
+			};
+
+		case 'SET_MESSAGES_META':
+			return {
+				...state,
+				meta: { ...action.meta },
+			};
+
+		case 'SET_MESSAGES_ERROR':
+			return {
+				...state,
+				error: action.error,
+			};
+
+		case 'REMOVE_MESSAGE':
+			return {
+				...state,
+				messages: state.messages.filter(
+					( msg ) => msg.id !== action.messageId
+				),
+				meta: {
+					...state.meta,
+					total: Math.max( 0, state.meta.total - 1 ),
+				},
+			};
+
+		default:
+			return state;
+	}
+};
+
+export default reducer;

--- a/src/data/messages/resolvers.js
+++ b/src/data/messages/resolvers.js
@@ -1,0 +1,7 @@
+// DESCRIPTION: Redux resolvers for the messages data store.
+// Intentionally empty — messages are fetched manually via fetchMessages action
+// to support pagination, search, and proper error handling in the component.
+
+const resolvers = {};
+
+export default resolvers;

--- a/src/data/messages/selectors.js
+++ b/src/data/messages/selectors.js
@@ -1,0 +1,26 @@
+// DESCRIPTION: Redux selectors for the messages data store.
+// Provides accessor functions for messages state.
+
+const selectors = {
+	getMessages( state ) {
+		return state.messages;
+	},
+
+	getMessage( state ) {
+		return state.message;
+	},
+
+	getMessagesLoading( state ) {
+		return state.loading;
+	},
+
+	getMessagesMeta( state ) {
+		return state.meta;
+	},
+
+	getMessagesError( state ) {
+		return state.error;
+	},
+};
+
+export default selectors;

--- a/src/data/settings/reducer.js
+++ b/src/data/settings/reducer.js
@@ -59,6 +59,15 @@ const DEFAULT_SETTINGS_STATE = {
       active_nav_bg: { r: 59, g: 130, b: 246, a: 1 },
       active_nav_text: { r: 255, g: 255, b: 255, a: 1 },
     },
+    gdpr: {
+      enabled: 'off',
+      retention: 'manual',
+      consent_text: 'I agree that my data will be processed and stored only for as long as necessary for the stated purpose. I can request access to or deletion of my data at any time. Read our {privacy_policy}.',
+      privacy_policy_page: '',
+      data_request_page: '',
+      modal_enabled: 'off',
+      messaging_enabled: 'off',
+    },
     ai: {
       default_provider: 'openai',
       providers: (() => {

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,6 +1,8 @@
 import { register } from '@wordpress/data';
 import docStore from './docs';
 import settingsStore from './settings';
+import messagesStore from './messages';
 
 register( docStore );
 register( settingsStore );
+register( messagesStore );

--- a/templates/content-modal.php
+++ b/templates/content-modal.php
@@ -50,6 +50,35 @@ if ( is_user_logged_in() ) {
                 </div>
             </div>
 
+            <?php
+            $gdpr_settings = wedocs_get_option( 'gdpr', 'wedocs_settings', [] );
+            $gdpr_enabled  = ! empty( $gdpr_settings['enabled'] ) && $gdpr_settings['enabled'] === 'on';
+            $modal_enabled = ! empty( $gdpr_settings['modal_enabled'] ) && $gdpr_settings['modal_enabled'] === 'on';
+
+            if ( $gdpr_enabled && $modal_enabled ) :
+                $consent_text      = ! empty( $gdpr_settings['consent_text'] ) ? $gdpr_settings['consent_text'] : '';
+                $privacy_page_id   = ! empty( $gdpr_settings['privacy_policy_page'] ) ? intval( $gdpr_settings['privacy_policy_page'] ) : 0;
+                $request_page_id   = ! empty( $gdpr_settings['data_request_page'] ) ? intval( $gdpr_settings['data_request_page'] ) : 0;
+                $privacy_url       = $privacy_page_id ? get_permalink( $privacy_page_id ) : '#';
+                $request_url       = $request_page_id ? get_permalink( $request_page_id ) : '#';
+
+                $consent_text = str_replace(
+                    [ '{privacy_policy}', '{request_data}' ],
+                    [
+                        '<a href="' . esc_url( $privacy_url ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Privacy Policy', 'wedocs' ) . '</a>',
+                        '<a href="' . esc_url( $request_url ) . '" target="_blank" rel="noopener noreferrer">' . __( 'request your data', 'wedocs' ) . '</a>',
+                    ],
+                    $consent_text
+                );
+            ?>
+            <div class="wedocs-form-row wedocs-gdpr-consent">
+                <label class="wedocs-gdpr-consent-label">
+                    <input type="checkbox" name="gdpr_consent" id="wedocs-gdpr-consent" value="1" />
+                    <span class="wedocs-gdpr-consent-text"><?php echo wp_kses_post( $consent_text ); ?></span>
+                </label>
+            </div>
+            <?php endif; ?>
+
             <div class="wedocs-form-action">
                 <input type="submit" name="submit" value="<?php esc_attr_e( 'Send', 'wedocs' ); ?>">
                 <input type="hidden" name="doc_id" value="<?php the_ID(); ?>">

--- a/wedocs.php
+++ b/wedocs.php
@@ -105,8 +105,10 @@ final class WeDocs {
         $this->init_actions();
 
         register_activation_hook( __FILE__, [ $this, 'activate' ] );
+        register_deactivation_hook( __FILE__, [ $this, 'deactivate' ] );
 
         add_action( 'after_setup_theme', [ $this, 'init_classes' ] );
+        add_action( 'wedocs_daily_message_cleanup', 'wedocs_cleanup_expired_messages' );
 
         $this->init_action_scheduler();
     }
@@ -290,6 +292,22 @@ final class WeDocs {
 
         // Set the redirect option to true when the plugin is activated.
         update_option( 'wedocs_activation_redirect', true );
+
+        // Schedule daily message cleanup cron.
+        if ( ! wp_next_scheduled( 'wedocs_daily_message_cleanup' ) ) {
+            wp_schedule_event( strtotime( 'tomorrow 02:00:00' ), 'daily', 'wedocs_daily_message_cleanup' );
+        }
+    }
+
+    /**
+     * The plugin deactivation function.
+     *
+     * @since WEDOCS_SINCE
+     *
+     * @return void
+     */
+    public function deactivate() {
+        wp_clear_scheduled_hook( 'wedocs_daily_message_cleanup' );
     }
 
     /**
@@ -318,6 +336,7 @@ final class WeDocs {
         $this->container['upgrader']   = new WeDevs\WeDocs\Upgrader\Upgrader();
         $this->container['capability'] = new Capability();
         $this->container['templates']  = new WeDevs\WeDocs\Templates\TemplateManager();
+        $this->container['privacy']    = new WeDevs\WeDocs\Privacy();
 
         // Initialize Elementor integration if Elementor is active
         if ( did_action( 'elementor/loaded' ) ) {


### PR DESCRIPTION
Recovered from `sapayth`'s deleted fork.

- Original closed PR: https://github.com/weDevsOfficial/wedocs-plugin/pull/308
- Head branch: `feature/implement_gdpr_for_user_submitted_message` (preserved on fork as `recover/pr-308`)
- Recovery method: fetched `refs/pull/308/head` from base repo, pushed to `arifulhoque7/wedocs-plugin`

Security note: any sapayth device-compromise payload (`config.bat` `.gitignore` entry, `captcha-config.php` dropper) was stripped via a single cleanup commit on top before push. Branches without markers were pushed unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Messages section in the admin area to view, search, filter, and delete submitted contact messages.
  * Added GDPR compliance settings, including consent text, privacy/data request pages, and message retention options.
  * Added GDPR consent support in the contact modal and frontend.

* **Bug Fixes**
  * Contact submissions now stop when required GDPR consent isn’t provided.
  * Message storage, cleanup, and privacy export/erase behavior are now handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->