### PR TITLE
Add Hooks and REST API docs (recover #307)

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,670 @@
+# weDocs Hooks Reference
+
+This document lists all action and filter hooks available in weDocs for developers to extend and customize the plugin's behavior.
+
+---
+
+## Action Hooks
+
+### `wedocs_before_main_content`
+
+Fires before the main documentation content on the single doc template.
+
+**Since:** 1.4
+
+**File:** `templates/single-docs.php`
+
+#### Description
+
+This action runs before the main content area on single documentation pages. By default, `wedocs_template_wrapper_start` is hooked at priority 10 to output the opening wrapper markup.
+
+#### Default Hooked Callbacks
+
+| Callback | Priority |
+|----------|----------|
+| `wedocs_template_wrapper_start` | 10 |
+
+#### Parameters
+
+None.
+
+#### Example
+
+```php
+add_action( 'wedocs_before_main_content', function () {
+    echo '<div class="my-custom-wrapper">';
+}, 5 );
+```
+
+---
+
+### `wedocs_after_main_content`
+
+Fires after the main documentation content on the single doc template.
+
+**Since:** 1.4
+
+**File:** `templates/single-docs.php`
+
+#### Description
+
+This action runs after the main content area on single documentation pages. By default, `wedocs_template_wrapper_end` is hooked at priority 10 to output the closing wrapper markup.
+
+#### Default Hooked Callbacks
+
+| Callback | Priority |
+|----------|----------|
+| `wedocs_template_wrapper_end` | 10 |
+
+#### Parameters
+
+None.
+
+#### Example
+
+```php
+add_action( 'wedocs_after_main_content', function () {
+    echo '</div><!-- .my-custom-wrapper -->';
+}, 15 );
+```
+
+---
+
+### `wedocs_settings_data_updated`
+
+Fires after plugin settings have been saved via the REST API.
+
+**Since:** 2.0.0
+
+**File:** `includes/API/SettingsApi.php`
+
+#### Description
+
+This action is triggered after weDocs settings are saved to the `wedocs_settings` option. It receives the filtered settings data that was just stored.
+
+#### Parameters
+
+- **$settings_data** (array) — The settings data that was saved, after being passed through the `wedocs_settings_data` filter.
+
+#### Example
+
+```php
+add_action( 'wedocs_settings_data_updated', function ( $settings_data ) {
+    // Flush rewrite rules when settings change.
+    flush_rewrite_rules();
+} );
+```
+
+---
+
+## Filter Hooks
+
+### `wedocs_theme_dir_path`
+
+Filters the theme directory path used for template overrides.
+
+**Since:** 1.0
+
+**File:** `wedocs.php`
+
+#### Parameters
+
+- **$path** (string) — Theme directory name. Default: `'wedocs/'`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_theme_dir_path', function ( $path ) {
+    return 'my-custom-docs/';
+} );
+```
+
+---
+
+### `wedocs_post_type`
+
+Filters the arguments passed to `register_post_type()` for the `docs` post type.
+
+**Since:** 1.0
+
+**File:** `includes/Post_Types.php`
+
+#### Parameters
+
+- **$args** (array) — The post type registration arguments.
+
+#### Example
+
+```php
+add_filter( 'wedocs_post_type', function ( $args ) {
+    $args['exclude_from_search'] = true;
+    return $args;
+} );
+```
+
+---
+
+### `wedocs_shortcode_page_parent_args`
+
+Filters the query arguments used to retrieve parent documentation pages in the shortcode.
+
+**Since:** 2.0.0
+
+**File:** `includes/Shortcode.php`
+
+#### Parameters
+
+- **$parent_args** (array) — Arguments passed to `get_pages()`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_shortcode_page_parent_args', function ( $args ) {
+    $args['sort_column'] = 'post_title';
+    return $args;
+} );
+```
+
+---
+
+### `wedocs_shortcode_page_section_args`
+
+Filters the query arguments used to retrieve section (child) docs in the shortcode.
+
+**Since:** 2.0.0
+
+**File:** `includes/Shortcode.php`
+
+#### Parameters
+
+- **$section_args** (array) — Arguments passed to `get_children()`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_shortcode_page_section_args', function ( $args ) {
+    $args['numberposts'] = 20;
+    return $args;
+} );
+```
+
+---
+
+### `wedocs_get_doc_listing_template_dir`
+
+Filters the template file name used for the docs listing shortcode output.
+
+**Since:** 2.0.0
+
+**File:** `includes/Shortcode.php`
+
+#### Parameters
+
+- **$template_dir** (string) — Template file name. Default: `'shortcode.php'`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_get_doc_listing_template_dir', function ( $template ) {
+    return 'custom-shortcode.php';
+} );
+```
+
+---
+
+### `wedocs_set_template_path`
+
+Filters the base file system path where weDocs looks for template files.
+
+**Since:** 2.0.0
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$path** (string) — The plugin's template directory path.
+- **$template** (string) — The resolved template file path (may be empty).
+- **$args** (array) — Template arguments.
+
+#### Example
+
+```php
+add_filter( 'wedocs_set_template_path', function ( $path, $template, $args ) {
+    return '/custom/path/to/templates';
+}, 10, 3 );
+```
+
+---
+
+### `wedocs_get_template_part`
+
+Filters the resolved template file path before it is included.
+
+**Since:** 2.0.0
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$template** (string) — Full path to the template file.
+- **$slug** (string) — The template slug.
+- **$name** (string) — The template name.
+
+#### Example
+
+```php
+add_filter( 'wedocs_get_template_part', function ( $template, $slug, $name ) {
+    if ( $slug === 'content' && $name === 'feedback' ) {
+        return get_stylesheet_directory() . '/wedocs/content-feedback.php';
+    }
+    return $template;
+}, 10, 3 );
+```
+
+---
+
+### `wedocs_breadcrumbs`
+
+Filters the breadcrumb configuration arguments.
+
+**Since:** 1.0
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$args** (array) — Breadcrumb arguments:
+  - **delimiter** (string) — HTML between breadcrumb items.
+  - **home** (string) — Home link label. Default: `'Home'`.
+  - **before** (string) — HTML before the current item.
+  - **after** (string) — HTML after the current item.
+
+#### Example
+
+```php
+add_filter( 'wedocs_breadcrumbs', function ( $args ) {
+    $args['delimiter'] = '<span class="sep"> / </span>';
+    return $args;
+} );
+```
+
+---
+
+### `wedocs_breadcrumbs_html`
+
+Filters the final breadcrumb HTML output before it is echoed.
+
+**Since:** 1.0
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$html** (string) — The generated breadcrumb HTML.
+- **$args** (array) — The breadcrumb arguments.
+
+#### Example
+
+```php
+add_filter( 'wedocs_breadcrumbs_html', function ( $html, $args ) {
+    return '<nav aria-label="breadcrumb">' . $html . '</nav>';
+}, 10, 2 );
+```
+
+---
+
+### `wedocs_translate_text`
+
+Filters translatable text strings, primarily post titles. Useful for multilingual plugins like qTranslate.
+
+**Since:** 1.0
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$text** (string) — The text to translate.
+
+#### Example
+
+```php
+add_filter( 'wedocs_translate_text', function ( $text ) {
+    return my_translate_function( $text );
+} );
+```
+
+---
+
+### `wedocs_email_feedback_to`
+
+Filters the recipient email address for doc feedback emails.
+
+**Since:** 1.2
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$email_to** (string) — Recipient email address.
+- **$doc_id** (int) — The documentation post ID.
+- **$document** (WP_Post) — The documentation post object.
+
+#### Example
+
+```php
+add_filter( 'wedocs_email_feedback_to', function ( $email_to, $doc_id, $document ) {
+    return 'support@example.com';
+}, 10, 3 );
+```
+
+---
+
+### `wedocs_email_feedback_subject`
+
+Filters the subject line for doc feedback emails.
+
+**Since:** 1.2
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$subject** (string) — Email subject.
+- **$doc_id** (int) — The documentation post ID.
+- **$document** (WP_Post) — The documentation post object.
+- **$post_data** (array) — The `$_POST` data from the form submission.
+
+#### Example
+
+```php
+add_filter( 'wedocs_email_feedback_subject', function ( $subject, $doc_id ) {
+    return '[Feedback] ' . get_the_title( $doc_id );
+}, 10, 2 );
+```
+
+---
+
+### `wedocs_email_feedback_body`
+
+Filters the body content of doc feedback emails.
+
+**Since:** 1.2
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$email_body** (string) — Email body text.
+- **$doc_id** (int) — The documentation post ID.
+- **$document** (WP_Post) — The documentation post object.
+- **$post_data** (array) — The `$_POST` data from the form submission.
+
+#### Example
+
+```php
+add_filter( 'wedocs_email_feedback_body', function ( $body, $doc_id, $document, $post_data ) {
+    $body .= "\r\nDoc URL: " . get_permalink( $doc_id );
+    return $body;
+}, 10, 4 );
+```
+
+---
+
+### `wedocs_email_feedback_headers`
+
+Filters the email headers for doc feedback emails.
+
+**Since:** 1.2
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$headers** (string) — Email headers.
+- **$doc_id** (int) — The documentation post ID.
+- **$document** (WP_Post) — The documentation post object.
+- **$post_data** (array) — The `$_POST` data from the form submission.
+
+#### Example
+
+```php
+add_filter( 'wedocs_email_feedback_headers', function ( $headers, $doc_id, $document, $post_data ) {
+    $headers .= "CC: manager@example.com\n";
+    return $headers;
+}, 10, 4 );
+```
+
+---
+
+### `wedocs_publish_cap`
+
+Filters the capability required to publish documentation.
+
+**Since:** 1.3
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$capability** (string) — The capability string. Default: `'manage_categories'`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_publish_cap', function ( $cap ) {
+    return 'edit_posts';
+} );
+```
+
+---
+
+### `wedocs_ai_provider_configs`
+
+Filters the AI provider configurations used for content generation.
+
+**Since:** 2.1.15
+
+**File:** `includes/functions.php`
+
+#### Parameters
+
+- **$provider_configs** (array) — Associative array of provider configurations. Each key is a provider slug (`openai`, `anthropic`, `google`) with:
+  - **name** (string) — Display name.
+  - **endpoint** (string) — API endpoint URL.
+  - **models** (array) — Key-value pairs of model ID to label.
+  - **requires_key** (bool) — Whether an API key is required.
+
+#### Example
+
+```php
+add_filter( 'wedocs_ai_provider_configs', function ( $configs ) {
+    // Add a custom AI provider.
+    $configs['custom_ai'] = [
+        'name'         => 'My Custom AI',
+        'endpoint'     => 'https://api.custom-ai.com/v1/generate',
+        'models'       => [ 'model-1' => 'Model One' ],
+        'requires_key' => true,
+    ];
+    return $configs;
+} );
+```
+
+---
+
+### `wedocs_upgrade_popup_content`
+
+Filters the content displayed in the "Free to Pro" upgrade popup.
+
+**Since:** 2.1.19
+
+**File:** `includes/functions.php`
+
+#### Description
+
+See [FILTERS.md](../FILTERS.md) in the plugin root for detailed documentation including default values and 5 usage examples.
+
+#### Parameters
+
+- **$content** (array) — Popup content data with keys: `title`, `subtitle`, `features`, `button_text`, `button_url`, `footer_features`.
+
+---
+
+### `wedocs_display_admin_footer_text`
+
+Filters whether to display the weDocs admin footer text (rating prompt).
+
+**Since:** 1.0
+
+**File:** `includes/Admin/Admin.php`
+
+#### Parameters
+
+- **$display** (bool) — Whether the current screen should show the footer text.
+
+#### Example
+
+```php
+add_filter( 'wedocs_display_admin_footer_text', '__return_false' );
+```
+
+---
+
+### `wedocs_settings_management_capabilities`
+
+Filters the capability required to access the Settings submenu.
+
+**Since:** 2.0.0
+
+**File:** `includes/Admin/Menu.php`
+
+#### Parameters
+
+- **$capability** (string) — The capability string. Default: the main weDocs menu capability.
+
+#### Example
+
+```php
+add_filter( 'wedocs_settings_management_capabilities', function ( $cap ) {
+    return 'manage_options';
+} );
+```
+
+---
+
+### `wedocs_migration_management_capabilities`
+
+Filters the capability required to access the Migration submenu.
+
+**Since:** 2.0.0
+
+**File:** `includes/Admin/Menu.php`
+
+#### Parameters
+
+- **$capability** (string) — The capability string. Default: `'manage_options'`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_migration_management_capabilities', function ( $cap ) {
+    return 'manage_options';
+} );
+```
+
+---
+
+### `wedocs_submenu`
+
+Filters the array of admin submenu items before they are registered.
+
+**Since:** 2.0.0
+
+**File:** `includes/Admin/Menu.php`
+
+#### Parameters
+
+- **$all_submenus** (array) — Array of submenu items. Each item is an array of `[ label, capability, menu_slug ]`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_submenu', function ( $submenus ) {
+    // Add a custom submenu.
+    $submenus[] = [
+        __( 'Analytics', 'my-plugin' ),
+        'manage_options',
+        'admin.php?page=wedocs#/analytics',
+    ];
+    return $submenus;
+} );
+```
+
+---
+
+### `wedocs_menu_position`
+
+Filters the position of the weDocs admin menu in the sidebar.
+
+**Since:** 2.0.0
+
+**File:** `includes/Admin/Menu.php`
+
+#### Parameters
+
+- **$position** (int) — Menu position. Default: `48`.
+
+#### Example
+
+```php
+add_filter( 'wedocs_menu_position', function ( $position ) {
+    return 25;
+} );
+```
+
+---
+
+### `wedocs_settings_data`
+
+Filters settings data before it is saved to the database.
+
+**Since:** 2.0.0
+
+**File:** `includes/API/SettingsApi.php`
+
+#### Parameters
+
+- **$settings_data** (array) — The settings data from the REST request.
+
+#### Example
+
+```php
+add_filter( 'wedocs_settings_data', function ( $data ) {
+    // Force a specific setting value.
+    $data['general']['print'] = 'on';
+    return $data;
+} );
+```
+
+---
+
+### `wedocs_settings_data_rest_response`
+
+Filters the REST API response data after settings have been saved.
+
+**Since:** 2.0.0
+
+**File:** `includes/API/SettingsApi.php`
+
+#### Parameters
+
+- **$settings_data_filtered** (array) — The saved (filtered) settings data.
+- **$settings_data** (array) — The original settings data from the request.
+
+#### Example
+
+```php
+add_filter( 'wedocs_settings_data_rest_response', function ( $filtered, $original ) {
+    $filtered['save_timestamp'] = current_time( 'timestamp' );
+    return $filtered;
+}, 10, 2 );
+```

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -1,0 +1,457 @@
+# weDocs REST API Reference
+
+All endpoints use the WordPress REST API under the `wp/v2` namespace. Authentication follows standard WordPress REST API conventions (cookie auth, application passwords, or nonce-based auth).
+
+---
+
+## Docs API
+
+**Controller:** `WeDevs\WeDocs\API\API`
+**Base:** `/wp/v2/docs`
+
+---
+
+### `POST /wp/v2/docs/{id}/feedback`
+
+Submit feedback on a documentation article.
+
+**Since:** 1.0
+
+**Permission:** Passes `create_item_permissions_check` (checks user creation capabilities).
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | integer | Yes (URL) | The documentation post ID. |
+| `name` | string | No | Sender's name. |
+| `email` | string (email) | No | Sender's email address. |
+| `subject` | string | Yes | Feedback subject line. |
+| `message` | string | Yes | Feedback message body. |
+
+#### Response
+
+Success response with feedback status.
+
+---
+
+### `PUT /wp/v2/docs/{id}/helpfullness`
+
+Mark a documentation article as helpful or not helpful.
+
+**Since:** 1.0
+
+**Permission:** `helpful_update_permissions_check`
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | integer | Yes (URL) | The documentation post ID. |
+| `type` | string | Yes | Vote type. Must be `positive` or `negative`. |
+
+#### Response
+
+Updated helpfulness data.
+
+---
+
+### `DELETE /wp/v2/docs/{id}/`
+
+Delete a documentation article.
+
+**Since:** 1.0
+
+**Permission:** `delete_item_permissions_check` (standard WordPress delete capability for the post).
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | integer | Yes (URL) | The documentation post ID. |
+| `force` | boolean | No | Whether to bypass trash and force deletion. Default: `false`. |
+
+#### Response
+
+The deleted post data.
+
+---
+
+### `GET /wp/v2/docs/{id}/parents`
+
+Retrieve the parent hierarchy of a documentation article.
+
+**Since:** 1.0
+
+**Permission:** `get_parents_permissions_check`
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | integer | Yes (URL) | The documentation post ID. |
+
+#### Response
+
+Array of parent posts in hierarchical order.
+
+---
+
+### `GET /wp/v2/docs/helpfulness`
+
+Get a list of documentation articles with helpfulness data.
+
+**Since:** 1.0
+
+**Permission:** Public (no authentication required).
+
+#### Parameters
+
+None.
+
+#### Response
+
+Array of docs with their helpfulness statistics.
+
+---
+
+### `GET /wp/v2/docs/contributors`
+
+Get a list of documentation contributors.
+
+**Since:** 1.0
+
+**Permission:** Public (no authentication required).
+
+#### Parameters
+
+None.
+
+#### Response
+
+Array of contributor user data.
+
+---
+
+### `GET /wp/v2/docs/search`
+
+Search across documentation articles.
+
+**Since:** 1.0
+
+**Permission:** Public (no authentication required).
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | Yes | — | Search query string. |
+| `in` | integer | No | — | Limit search to children of this parent doc ID. |
+| `page` | integer | No | `1` | Page number for pagination. Minimum: `1`. |
+| `per_page` | integer | No | `10` | Results per page. Range: `1`–`100`. |
+
+#### Response
+
+Array of matching documentation posts with pagination headers.
+
+---
+
+### `GET /wp/v2/docs/sorting_status`
+
+Get the current sorting status.
+
+**Since:** 2.0.0
+
+**Permission:** `sortable_item_permissions_check` (requires `edit_docs` capability).
+
+#### Parameters
+
+None.
+
+#### Response
+
+The current sorting status (boolean).
+
+---
+
+### `POST /wp/v2/docs/sorting_status`
+
+Update sorting status and reorder documentation.
+
+**Since:** 2.0.0
+
+**Permission:** `sortable_item_permissions_check` (requires `edit_docs` capability).
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sortable_status` | boolean | Yes | Whether sorting is active. |
+| `documentations` | object | Yes | Object containing documentation items with their new order. Each item has `id` (int). |
+
+#### Response
+
+Updated sorting status.
+
+---
+
+### `GET /wp/v2/docs/need_sorting_status`
+
+Check if documentation needs re-sorting.
+
+**Since:** 2.0.0
+
+**Permission:** `sortable_item_permissions_check` (requires `edit_docs` capability).
+
+#### Parameters
+
+None.
+
+#### Response
+
+Boolean indicating whether sorting is needed.
+
+---
+
+### `POST /wp/v2/docs/need_sorting_status`
+
+Update whether documentation needs re-sorting.
+
+**Since:** 2.0.0
+
+**Permission:** `sortable_item_permissions_check` (requires `edit_docs` capability).
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `need_sortable_status` | boolean | Yes | Whether sorting is needed. |
+
+#### Response
+
+The updated status.
+
+---
+
+### `POST /wp/v2/docs/update_docs_status`
+
+Bulk update the publish status of multiple documentation articles.
+
+**Since:** 2.0.2
+
+**Permission:** `sortable_item_permissions_check` (requires `edit_docs` capability).
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | object | Yes | Object containing: |
+| `data.docIds` | object | Yes | Object of documentation post IDs. |
+| `data.status` | string | Yes | The new post status to apply. |
+
+#### Response
+
+Success confirmation.
+
+---
+
+### `GET /wp/v2/docs/promotion-notice`
+
+Get the current promotional notice data.
+
+**Since:** 2.0.0
+
+**Permission:** `get_promotional_notice_check` (admin only).
+
+#### Parameters
+
+None.
+
+#### Response
+
+Promotional notice data or empty if no active promotion.
+
+---
+
+### `POST /wp/v2/docs/hide-promotion-notice`
+
+Dismiss/hide the current promotional notice.
+
+**Since:** 2.0.0
+
+**Permission:** `get_promotional_notice_check` (admin only).
+
+#### Parameters
+
+None.
+
+#### Response
+
+Success confirmation.
+
+---
+
+### `POST /wp/v2/docs/ai/generate`
+
+Generate documentation content using AI.
+
+**Since:** 2.1.15
+
+**Permission:** `ai_generate_permissions_check` (admin only).
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `prompt` | string | Yes | — | The text prompt for content generation. |
+| `provider` | string | No | Configured default | AI provider slug (`openai`, `anthropic`, `google`). |
+| `model` | string | No | Provider default | Specific model ID to use. |
+| `maxTokens` | integer | No | `2000` | Maximum tokens in the response. |
+| `temperature` | number | No | `0.7` | Sampling temperature (0–1). |
+| `systemPrompt` | string | No | — | System-level instructions for the AI. |
+
+#### Response
+
+Generated content from the AI provider.
+
+---
+
+## Settings API
+
+**Controller:** `WeDevs\WeDocs\API\SettingsApi`
+**Base:** `/wp/v2/docs/settings`
+
+---
+
+### `GET /wp/v2/docs/settings`
+
+Retrieve plugin settings.
+
+**Since:** 2.0.0
+
+**Permission:** `manage_options` capability required.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | string | No | Settings key to retrieve. Use `wedocs_settings` to get all settings. |
+
+#### Response
+
+The settings data object.
+
+---
+
+### `POST /wp/v2/docs/settings`
+
+Save plugin settings.
+
+**Since:** 2.0.0
+
+**Permission:** `manage_options` capability required.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `settings` | object | Yes | The settings data to save. |
+| `upgrade` | boolean | No | Whether this is an upgrade-related settings update. |
+
+#### Response
+
+The saved settings data (after filtering).
+
+#### Hooks Fired
+
+- `wedocs_settings_data` — Filter applied to settings before saving.
+- `wedocs_settings_data_rest_response` — Filter applied to the response.
+- `wedocs_settings_data_updated` — Action fired after settings are saved.
+
+---
+
+### `GET /wp/v2/docs/settings/turnstile-site-key`
+
+Get the Cloudflare Turnstile site key for the assistant widget.
+
+**Since:** 2.0.0
+
+**Permission:** Public (no authentication required).
+
+#### Parameters
+
+None.
+
+#### Response
+
+The Turnstile site key string (empty string if not configured).
+
+---
+
+## Upgrader API
+
+**Controller:** `WeDevs\WeDocs\API\UpgraderApi`
+**Base:** `/wp/v2/docs/upgrade`
+
+---
+
+### `GET /wp/v2/docs/upgrade`
+
+Check if a database upgrade is needed and get the current upgrade status.
+
+**Since:** 2.0.0
+
+**Permission:** `read` capability required.
+
+#### Parameters
+
+None.
+
+#### Response
+
+```json
+{
+    "status": "running|close|null",
+    "need_upgrade": true|false
+}
+```
+
+---
+
+### `POST /wp/v2/docs/upgrade`
+
+Trigger the database upgrade process. Enqueues an async action via Action Scheduler.
+
+**Since:** 2.0.0
+
+**Permission:** `manage_options` capability required.
+
+#### Parameters
+
+None.
+
+#### Response
+
+```json
+{
+    "message": "Processing Upgrade in the background."
+}
+```
+
+---
+
+### `POST /wp/v2/docs/upgrade/done`
+
+Mark the database upgrade process as complete.
+
+**Since:** 2.0.0
+
+**Permission:** `manage_options` capability required.
+
+#### Parameters
+
+None.
+
+#### Response
+
+Boolean indicating whether the option was updated successfully.


### PR DESCRIPTION
Recovered from `sapayth`'s deleted fork.

- Original closed PR: https://github.com/weDevsOfficial/wedocs-plugin/pull/307
- Head branch: `docs/hooks_and_rest_api` (preserved on fork as `recover/pr-307`)
- Recovery method: fetched `refs/pull/307/head` from base repo, pushed to `arifulhoque7/wedocs-plugin`

Security note: any sapayth device-compromise payload (`config.bat` `.gitignore` entry, `captcha-config.php` dropper) was stripped via a single cleanup commit on top before push. Branches without markers were pushed unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive hooks reference documentation covering action and filter hooks with parameters, version information, and usage examples
  * Added REST API endpoints documentation detailing available endpoints, controllers, request parameters, and response schemas

* **Chores**
  * Bumped version to 2.2.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->