### PR TITLE
Add Dokan active flag and gate vendor action

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -76,7 +76,7 @@ class Assets {
                     'hasManageCap'  => current_user_can( 'manage_options' ),
                     'weDocsUrl'     => admin_url( 'admin.php?page=wedocs#/' ),
                     'pro_active'    => wedocs_is_pro_active(),
-                    'dokan_active'  => function_exists( 'dokan' ),
+                    'dokan_active'  => is_plugin_active( 'dokan-lite/dokan.php' ),
                     'upgradePopupContent' => wedocs_get_upgrade_popup_content(),
                     'siteUrl'       => home_url( '/' ),
                 ),

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -76,6 +76,7 @@ class Assets {
                     'hasManageCap'  => current_user_can( 'manage_options' ),
                     'weDocsUrl'     => admin_url( 'admin.php?page=wedocs#/' ),
                     'pro_active'    => wedocs_is_pro_active(),
+                    'dokan_active'  => function_exists( 'dokan' ),
                     'upgradePopupContent' => wedocs_get_upgrade_popup_content(),
                     'siteUrl'       => home_url( '/' ),
                 ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weDocs",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weDocs",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "GPL",
       "dependencies": {
         "@dnd-kit/core": "^6.0.7",

--- a/src/components/DocActions.js
+++ b/src/components/DocActions.js
@@ -26,6 +26,8 @@ const DocActions = ( { doc, type, section, sections, setShowArticles } ) => {
   const [ isVendorDoc, setIsVendorDoc ] = useState( doc?.meta?._is_vendor_doc === '1' );
   const [ isUpgradeOpen, setIsUpgradeOpen ] = useState( false );
 
+  // Vendor docs are a Dokan integration: only expose the action when Dokan is active.
+  const isDokanActive = !! weDocsAdminVars?.dokan_active;
   const { isGated } = useVendorDocGating();
 
   // Toggle vendor doc meta.
@@ -125,7 +127,7 @@ const DocActions = ( { doc, type, section, sections, setShowArticles } ) => {
             { __( 'View', 'wedocs' ) }
           </a>
 
-          { type === 'doc' && (
+          { isDokanActive && type === 'doc' && (
             <button
               type="button"
               onClick={ toggleVendorDoc }


### PR DESCRIPTION
Expose a dokan_active flag in weDocs admin vars and update DocActions to only show the vendor-doc action when Dokan is active. This prevents vendor-specific UI from appearing when the Dokan plugin isn’t present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dokan plugin integration: The system now detects whether the Dokan vendor management plugin is installed and active. Vendor-specific document actions are conditionally displayed in the interface only when Dokan is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->