### PR TITLE
Changelog: Pro preview teaser + upsell menu (free)

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -16,6 +16,7 @@ class Admin {
         new Admin\Admin();
         new Admin\Migrate();
         new Admin\Docs_List_Table();
+        new Admin\ChangelogUpsell();
 
         add_action( 'admin_init', array( $this, 'init_admin_actions' ), 5 );
 

--- a/includes/Admin/ChangelogUpsell.php
+++ b/includes/Admin/ChangelogUpsell.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace WeDevs\WeDocs\Admin;
+
+/**
+ * Free "Changelogs" submenu — a Pro upsell.
+ *
+ * Registered only when weDocs Pro is not active (Pro ships the real screen).
+ * Sits under the weDocs menu, right after Docs.
+ */
+class ChangelogUpsell {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_page' ], 20 );
+        add_action( 'admin_menu', [ $this, 'reorder_menu' ], 999 );
+    }
+
+    /**
+     * Whether weDocs Pro is active.
+     *
+     * @return bool
+     */
+    private function is_pro_active() {
+        return ( function_exists( 'wedocs_is_pro_active' ) && wedocs_is_pro_active() ) || defined( 'WEDOCS_PRO_VERSION' );
+    }
+
+    /**
+     * Register the submenu page.
+     *
+     * @return void
+     */
+    public function register_page() {
+        if ( $this->is_pro_active() ) {
+            return;
+        }
+
+        $cap = function_exists( 'wedocs_get_publish_cap' ) ? wedocs_get_publish_cap() : 'edit_posts';
+
+        add_submenu_page(
+            'wedocs',
+            __( 'Changelogs', 'wedocs' ),
+            __( 'Changelogs', 'wedocs' ),
+            $cap,
+            'wedocs-changelog',
+            [ $this, 'render' ]
+        );
+    }
+
+    /**
+     * Move the Changelogs submenu directly below Docs.
+     *
+     * @return void
+     */
+    public function reorder_menu() {
+        global $submenu;
+
+        if ( $this->is_pro_active() || empty( $submenu['wedocs'] ) ) {
+            return;
+        }
+
+        $index = null;
+        foreach ( $submenu['wedocs'] as $i => $item ) {
+            if ( isset( $item[2] ) && 'wedocs-changelog' === $item[2] ) {
+                $index = $i;
+                break;
+            }
+        }
+
+        if ( null === $index ) {
+            return;
+        }
+
+        $entry = $submenu['wedocs'][ $index ];
+        unset( $submenu['wedocs'][ $index ] );
+        $submenu['wedocs'] = array_values( $submenu['wedocs'] );
+        array_splice( $submenu['wedocs'], 1, 0, [ $entry ] );
+    }
+
+    /**
+     * Render the upsell screen.
+     *
+     * @return void
+     */
+    public function render() {
+        $upgrade = apply_filters( 'wedocs_changelog_upgrade_url', 'https://wedocs.co/pricing/?utm_source=wp-admin&utm_medium=changelog-menu' );
+
+        $features = [
+            __( 'Publish a beautiful changelog timeline at /changelog', 'wedocs' ),
+            __( 'Group updates into channels (Free, Pro, …) with their own pages', 'wedocs' ),
+            __( 'Colour-coded categories: Fixes, Improvements, New feature, New releases', 'wedocs' ),
+            __( 'Customisable header banner, brand colour and RSS feed', 'wedocs' ),
+            __( 'Embed anywhere with the [wedocs_changelog] shortcode', 'wedocs' ),
+        ];
+        ?>
+        <div class="wrap">
+            <div style="max-width:720px;margin:40px auto 0;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:40px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.05);">
+                <span style="display:inline-block;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:#4f46e5;background:#eef2ff;border-radius:9999px;padding:5px 12px;">
+                    <?php esc_html_e( 'Pro feature', 'wedocs' ); ?>
+                </span>
+                <h1 style="font-size:28px;margin:18px 0 8px;color:#111827;"><?php esc_html_e( 'Changelog', 'wedocs' ); ?></h1>
+                <p style="font-size:15px;color:#6b7280;margin:0 auto 24px;max-width:520px;">
+                    <?php esc_html_e( 'Keep your users in the loop with a polished, filterable changelog for your product — available in weDocs Pro.', 'wedocs' ); ?>
+                </p>
+
+                <ul style="text-align:left;max-width:520px;margin:0 auto 28px;padding:0;list-style:none;">
+                    <?php foreach ( $features as $feature ) : ?>
+                        <li style="display:flex;align-items:flex-start;gap:10px;margin:0 0 12px;color:#374151;font-size:14px;">
+                            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" style="flex-shrink:0;margin-top:1px;"><circle cx="10" cy="10" r="10" fill="#ecfdf5"/><path d="M6 10.5l2.5 2.5L14 7" stroke="#15a66e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                            <span><?php echo esc_html( $feature ); ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+
+                <a href="<?php echo esc_url( $upgrade ); ?>" target="_blank" rel="noopener" class="button button-primary button-hero" style="background:#4f46e5;border-color:#4f46e5;">
+                    <?php esc_html_e( 'Upgrade to Pro', 'wedocs' ); ?>
+                </a>
+            </div>
+        </div>
+        <?php
+    }
+}

--- a/src/components/ProPreviews/ChangelogSettings.js
+++ b/src/components/ProPreviews/ChangelogSettings.js
@@ -1,0 +1,98 @@
+import { __ } from '@wordpress/i18n';
+import Overlay from './common/Overlay';
+import { useState } from '@wordpress/element';
+
+/**
+ * Pro preview for the Changelog settings (shown in free; locked behind an
+ * upgrade overlay). Static mock only — no functional controls.
+ */
+const ChangelogSettings = () => {
+	const [ showOverlay, setShowOverlay ] = useState( false );
+
+	const modes = [
+		{
+			title: __( 'Single changelog', 'wedocs' ),
+			desc: __( 'One timeline at /changelog with every update. Channels become filters.', 'wedocs' ),
+			active: true,
+		},
+		{
+			title: __( 'Separate per channel', 'wedocs' ),
+			desc: __( 'Each channel is its own changelog at <base>/<channel>.', 'wedocs' ),
+			active: false,
+		},
+	];
+
+	const categories = [
+		{ name: __( 'Fixes', 'wedocs' ), color: '#b45309' },
+		{ name: __( 'Improvements', 'wedocs' ), color: '#15a66e' },
+		{ name: __( 'New feature', 'wedocs' ), color: '#0ea5e9' },
+		{ name: __( 'New releases', 'wedocs' ), color: '#4f46e5' },
+	];
+
+	return (
+		<section>
+			<div className="shadow sm:rounded-md bg-white min-h-[500px] relative">
+				<div className="py-4 px-8">
+					<h2 className="text-gray-900 font-medium text-lg">{ __( 'Changelog', 'wedocs' ) }</h2>
+				</div>
+				<hr className="h-px !bg-gray-200 border-0" />
+
+				<div
+					className="pt-6 pb-20 px-8 relative"
+					onMouseEnter={ () => setShowOverlay( true ) }
+					onMouseLeave={ () => setShowOverlay( false ) }
+				>
+					<label className="block text-sm font-medium text-gray-600 mb-2">{ __( 'Display mode', 'wedocs' ) }</label>
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+						{ modes.map( ( m, i ) => (
+							<div
+								key={ i }
+								className={ `relative rounded-lg border bg-white p-4 shadow-sm ${ m.active ? 'border-indigo-600 ring-1 ring-indigo-600' : 'border-gray-300' }` }
+							>
+								<span className="flex items-center text-sm font-semibold text-gray-900">
+									{ m.title }
+									<span className={ `ml-auto flex items-center justify-center rounded-full w-5 h-5 ${ m.active ? 'bg-indigo-600' : 'border border-gray-300' }` }>
+										{ m.active && (
+											<svg className="w-3.5 h-3.5 text-white" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2.5"><path strokeLinecap="round" strokeLinejoin="round" d="M5 10l3.5 3.5L15 6" /></svg>
+										) }
+									</span>
+								</span>
+								<span className="mt-1.5 block text-xs text-gray-500">{ m.desc }</span>
+							</div>
+						) ) }
+					</div>
+
+					<label className="block text-sm font-medium text-gray-600 mb-2">{ __( 'URL base', 'wedocs' ) }</label>
+					<div className="flex items-stretch max-w-lg rounded-md border border-gray-300 overflow-hidden mb-6">
+						<span className="flex items-center bg-gray-50 text-gray-400 text-sm px-3 border-r border-gray-300">{ window.location.host }/</span>
+						<span className="flex-1 h-10 px-2 text-sm text-gray-800 flex items-center">changelog</span>
+					</div>
+
+					<div className="flex items-center justify-between max-w-lg mb-6">
+						<label className="block text-sm font-medium text-gray-600">{ __( 'Header banner', 'wedocs' ) }</label>
+						<span className="relative inline-flex h-5 w-10 items-center rounded-full bg-indigo-600">
+							<span className="inline-block h-5 w-5 rounded-full border border-gray-200 bg-white shadow translate-x-5" />
+						</span>
+					</div>
+
+					<label className="block text-sm font-medium text-gray-600 mb-3">{ __( 'Categories', 'wedocs' ) }</label>
+					<div className="grid grid-cols-2 sm:grid-cols-3 gap-x-10 gap-y-5">
+						{ categories.map( ( c, i ) => (
+							<div key={ i } className="flex items-center gap-4">
+								<span className="flex justify-center items-center space-x-1 px-2 py-1.5 rounded-md bg-white border border-[#E2E2E2]">
+									<span style={ { background: c.color } } className="block w-6 h-6 rounded-full" />
+									<svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 stroke-gray-500"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" /></svg>
+								</span>
+								<span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold" style={ { background: c.color + '26', color: `color-mix(in srgb, ${ c.color } 64%, #000)` } }>{ c.name }</span>
+							</div>
+						) ) }
+					</div>
+
+					<Overlay classes={ `${ showOverlay ? 'flex items-center justify-center' : 'hidden' }` } />
+				</div>
+			</div>
+		</section>
+	);
+};
+
+export default ChangelogSettings;

--- a/src/components/ProPreviews/index.js
+++ b/src/components/ProPreviews/index.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import PermissionSettings from './PermissionSettings';
+import ChangelogSettings from './ChangelogSettings';
 import { userIsAdmin } from '../../utils/helper';
 import UpgradePopup from './common/UpgradePopup';
 import LayoutSettings from './LayoutSettings';
@@ -18,6 +19,27 @@ wp.hooks.addFilter(
         // Check if Pro is loaded dynamically
         const isProLoaded = wp.hooks.applyFilters('wedocs_pro_loaded', false);
         if (isProLoaded) return menus;
+            menus.changelog = {
+                pro: true,
+                text: __( 'Changelog', 'wedocs' ),
+                icon: (
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#6b7280"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="-ml-1 mr-4 pro-settings"
+                    >
+                        <path d="M3 11l18-5v12L3 14v-3z" />
+                        <path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+                    </svg>
+                ),
+            };
             menus.permission = {
                 pro: true,
                 text: __( 'Permission Management', 'wedocs' ),
@@ -190,6 +212,7 @@ wp.hooks.addFilter(
 
             return [
                 ...templates,
+                <ChangelogSettings key={ index } />,
                 <PermissionSettings key={ index } />,
                 ...assistantWidgetSubPanels,
                 <LayoutSettings


### PR DESCRIPTION
Free-side support for the Pro Changelog module.

- **Settings teaser** — a locked **Changelog** tab (ProPreviews) shown in the free plugin when Pro is inactive, using the existing preview + upgrade-overlay pattern. Hidden when Pro is active (`wedocs_pro_loaded`).
- **Upsell menu** — a **Changelogs** submenu under weDocs (right after Docs) that opens a Pro upsell page; registered only when Pro is not active (no clash with the real Pro screen).

Pairs with weDevsOfficial/wedocs-pro#342.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Changelogs” admin menu item for users who don’t have Pro enabled.
  * Added a preview of Changelog settings in the admin settings area, including display options, URL setup, header banner, and category chips.
  * The new screen includes an upgrade prompt with a link to Pro pricing.

* **Bug Fixes**
  * The new menu item is placed directly under Docs for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->