### PR TITLE
Show Pro-only General/AI settings as disabled

### DIFF
--- a/src/components/ProPreviews/AiImageAnalysisPreview.js
+++ b/src/components/ProPreviews/AiImageAnalysisPreview.js
@@ -17,17 +17,11 @@ const AiImageAnalysisPreview = () => {
 			<div className="settings-content flex items-center justify-between">
 				<div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
 					<label
-						className="block text-sm font-medium text-gray-700"
+						className="block text-sm font-medium text-gray-400"
 						id="headlessui-listbox-label-image-analysis"
 					>
 						{__('Enable image analysis', 'wedocs')}
-					</label>
-					<Badge 
-						classes="opacity-100" 
-						heading={__('Pro Feature', 'wedocs')}
-						description={__('Upload screenshots for AI to analyze when generating documentation', 'wedocs')}
-					/>
-					<div
+					</label>					<div
 						className="tooltip cursor-pointer ml-2"
 						data-tip={__(
 							'Allow AI to analyze uploaded screenshots when generating documentation',
@@ -76,20 +70,20 @@ const AiImageAnalysisPreview = () => {
 						/>
 					</button>
 					<span className="ml-3">
-						<span className="text-sm text-gray-900">
+						<span className="text-sm text-gray-400">
 							{__('Disable', 'wedocs')}
 						</span>
 					</span>
 				</div>
 			</div>
 			<div className="settings-description w-full max-w-[490px] ml-auto mt-1">
-				<p className="text-sm text-[#6B7280]">
+				<p className="text-sm text-gray-400">
 					{__(
 						'Allow AI to analyze uploaded screenshots when generating documentation. Useful for documenting UI flows, onboarding steps, and feature screenshots.',
 						'wedocs'
 					)}
 				</p>
-				<p className="text-sm text-amber-600 mt-2 flex items-center">
+				<p className="text-sm text-gray-400 mt-2 flex items-center">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						width="16"

--- a/src/components/ProPreviews/SocialShareSettings.js
+++ b/src/components/ProPreviews/SocialShareSettings.js
@@ -55,11 +55,7 @@ const SocialShareSettings = ( { settingsData, setSettings } ) => {
 								</div>
 							</div>
 							<div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
-								<div className="flex items-center space-x-2">
-									<span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full font-medium">
-										PRO
-									</span>
-									<SwitcherComponent
+								<div className="flex items-center space-x-2">									<SwitcherComponent
 										name="social_share"
 										settingsPanel={ general }
 										settingsData={ settingsData }

--- a/src/components/Settings/GeneralSettings.js
+++ b/src/components/Settings/GeneralSettings.js
@@ -52,13 +52,13 @@ const GeneralSettings = ( {
       <>
         <span className="block">
           {__('Before Doc: ', 'wedocs')}
-          <code className="text-indigo-700 bg-gray-50 px-1 py-0.5 rounded break-all">
+          <code className="text-gray-400 bg-gray-50 px-1 py-0.5 rounded break-all">
             {beforeDocUrl}
           </code>
         </span>
         <span className="block mt-2">
           {__('After Doc: ', 'wedocs')}
-          <code className="text-indigo-700 bg-gray-50 px-1 py-0.5 rounded break-all">
+          <code className="text-gray-400 bg-gray-50 px-1 py-0.5 rounded break-all">
             {afterDocUrl}
           </code>
         </span>
@@ -121,7 +121,7 @@ const GeneralSettings = ( {
             <div className="col-span-4">
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-field-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
-                  <label className="block text-sm font-medium text-gray-600">
+                  <label className={`block text-sm font-medium ${ applyFilters('wedocs_pro_loaded', false) ? 'text-gray-600' : 'text-gray-400' }`}>
                     {__('Docs URL Structure', 'wedocs')}
                   </label>
                   {!applyFilters('wedocs_pro_loaded', false) && (
@@ -183,14 +183,20 @@ const GeneralSettings = ( {
                 </div>
               </div>
               <div className="settings-description w-full max-w-[490px] ml-auto mt-1">
-                <p className="text-sm text-[#6B7280]">
-                  {renderUrlStructureDescription()}
-                  <span className="block mt-2">
-                    {__(
-                        'Changing this structure updates URLs and breadcrumbs for all docs. Previous URLs will automatically redirect (301).',
-                        'wedocs'
-                    )}
-                  </span>
+                <p className={`text-sm ${ applyFilters('wedocs_pro_loaded', false) ? 'text-[#6B7280]' : 'text-gray-400' }`}>
+                  {applyFilters('wedocs_pro_loaded', false) ? (
+                    <>
+                      {renderUrlStructureDescription()}
+                      <span className="block mt-2">
+                        {__(
+                            'Changing this structure updates URLs and breadcrumbs for all docs. Previous URLs will automatically redirect (301).',
+                            'wedocs'
+                        )}
+                      </span>
+                    </>
+                  ) : (
+                    __('Choose how doc URLs and breadcrumbs are structured — changing it updates all docs with automatic 301 redirects.', 'wedocs')
+                  )}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Pro-locked settings in the free plugin rendered as if active (full-colour label, live-looking controls), which was confusing next to real settings.

- **Docs URL Structure** — mute the label, dropdown (removed an overlay/stacking bug) and the description; drop the PRO badge; condense the free help text to one line.
- **Enable image analysis** — mute the label, toggle text and notes; drop the PRO badge.
- **Enable Social Share** — drop the redundant PRO badge.

All gated by `wedocs_pro_loaded` — styling reverts to normal when Pro is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated several settings screens with lighter gray text and cleaner spacing for a more consistent look.
  * Removed a few visible “PRO”/badge labels from certain options.
  * Refined the URL structure help text to show clearer messaging depending on the available product version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->