### PR TITLE
fix(security): harden AI summary, docs listing, QuickSearch & feedback endpoints

### DIFF
--- a/includes/API/API.php
+++ b/includes/API/API.php
@@ -472,7 +472,7 @@ class API extends WP_REST_Controller {
             [
                 'methods'             => WP_REST_Server::CREATABLE,
                 'callback'            => [ $this, 'generate_ai_summary' ],
-                'permission_callback' => '__return_true', // Allow public access for frontend generation
+                'permission_callback' => [ $this, 'generate_summary_permissions_check' ],
                 'args'                => [
                     'id' => [
                         'validate_callback' => function( $param, $request, $key ) {
@@ -808,7 +808,7 @@ class API extends WP_REST_Controller {
             foreach ( $doc_contributors as $contributor_id ) {
                 $user_data               = get_userdata( $contributor_id );
                 $data[ $contributor_id ] = array(
-                    'name' => $user_data->user_login,
+                    'name' => $user_data->display_name,
                     'src' => get_avatar_url( $contributor_id )
                 );
             }
@@ -2689,6 +2689,44 @@ class API extends WP_REST_Controller {
     }
 
     /**
+     * Permission check for AI summary generation.
+     *
+     * Keeps the public "Generate AI Summary" button working for published docs
+     * while preventing anonymous callers from summarising unpublished content
+     * and rate-limiting anonymous requests to curb paid-API cost abuse.
+     *
+     * @since 2.3.2
+     *
+     * @param WP_REST_Request $request full data about the request
+     *
+     * @return bool|WP_Error
+     */
+    public function generate_summary_permissions_check( $request ) {
+        $doc = get_post( (int) $request->get_param( 'id' ) );
+
+        if ( ! $doc || 'docs' !== $doc->post_type ) {
+            return new WP_Error( 'wedocs_invalid_doc', __( 'Invalid documentation post.', 'wedocs' ), [ 'status' => 404 ] );
+        }
+
+        // Editors may summarise any doc.
+        if ( current_user_can( 'edit_docs' ) ) {
+            return true;
+        }
+
+        // Anonymous / low-privilege callers: published docs only.
+        if ( 'publish' !== $doc->post_status ) {
+            return new WP_Error( 'wedocs_forbidden', __( 'You are not allowed to generate this summary.', 'wedocs' ), [ 'status' => 403 ] );
+        }
+
+        // Rate-limit anonymous requests to prevent AI cost abuse.
+        if ( ! wedocs_rate_limit_ok( 'ai_summary', 5, HOUR_IN_SECONDS ) ) {
+            return new WP_Error( 'wedocs_rate_limited', __( 'Too many requests. Please try again later.', 'wedocs' ), [ 'status' => 429 ] );
+        }
+
+        return true;
+    }
+
+    /**
      * Generate AI summary for a doc
      *
      * @since 2.0.0
@@ -2785,8 +2823,8 @@ class API extends WP_REST_Controller {
                 0.5  // Lower temperature for more focused summaries
             );
 
-            // Save the generated summary
-            $summary = $response['content'];
+            // Save the generated summary (sanitize AI HTML before storing).
+            $summary = wp_kses_post( $response['content'] );
             update_post_meta( $post_id, '_wedocs_ai_summary', $summary );
 
             return rest_ensure_response( [

--- a/includes/API/API.php
+++ b/includes/API/API.php
@@ -806,7 +806,10 @@ class API extends WP_REST_Controller {
             $data             = array();
             $doc_contributors = (array) get_post_meta( $doc->ID, 'wedocs_contributors', true );
             foreach ( $doc_contributors as $contributor_id ) {
-                $user_data               = get_userdata( $contributor_id );
+                $user_data = get_userdata( $contributor_id );
+                if ( ! $user_data ) {
+                    continue;
+                }
                 $data[ $contributor_id ] = array(
                     'name' => $user_data->display_name,
                     'src' => get_avatar_url( $contributor_id )

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -63,9 +63,12 @@ class Ajax {
     public function get_docs() {
         check_ajax_referer('wedocs-ajax');
 
+        // Only users who can edit docs may see unpublished documentation.
+        $statuses = current_user_can( 'edit_docs' ) ? ['publish', 'draft', 'pending'] : ['publish'];
+
         $docs = get_posts([
             'post_type'      => 'docs',
-            'post_status'    => ['publish', 'draft', 'pending'],
+            'post_status'    => $statuses,
             'posts_per_page' => -1,
             'orderby'        => 'menu_order',
             'order'          => 'ASC',
@@ -175,6 +178,11 @@ class Ajax {
         $previous = isset($_COOKIE['wedocs_response']) ? explode(',', $_COOKIE['wedocs_response']) : [];
         $post_id  = intval($_POST['post_id']);
         $type     = in_array($_POST['type'], ['positive', 'negative']) ? $_POST['type'] : false;
+
+        // Only documentation posts accept feedback votes.
+        if ( 'docs' !== get_post_type( $post_id ) ) {
+            wp_send_json_error( __( 'Invalid post.', 'wedocs' ) );
+        }
 
         // check previous response
         if (in_array($post_id, $previous)) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1182,3 +1182,33 @@ function use_wedocs_legacy_template(){
 
     return false;
 }
+
+if ( ! function_exists( 'wedocs_rate_limit_ok' ) ) {
+    /**
+     * Simple per-IP transient rate limiter.
+     *
+     * Allows up to $max hits from a single IP within $window seconds for a
+     * given bucket. Used to bound abuse of unauthenticated endpoints.
+     *
+     * @since 2.3.2
+     *
+     * @param string $bucket Logical action name.
+     * @param int    $max    Max allowed hits per window.
+     * @param int    $window Window length in seconds.
+     *
+     * @return bool True when the request is within the limit.
+     */
+    function wedocs_rate_limit_ok( $bucket, $max, $window ) {
+        $ip   = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : 'unknown';
+        $key  = 'wedocs_rl_' . $bucket . '_' . md5( $ip );
+        $hits = (int) get_transient( $key );
+
+        if ( $hits >= $max ) {
+            return false;
+        }
+
+        set_transient( $key, $hits + 1, $window );
+
+        return true;
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1201,13 +1201,23 @@ if ( ! function_exists( 'wedocs_rate_limit_ok' ) ) {
     function wedocs_rate_limit_ok( $bucket, $max, $window ) {
         $ip   = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : 'unknown';
         $key  = 'wedocs_rl_' . $bucket . '_' . md5( $ip );
-        $hits = (int) get_transient( $key );
+        $data = get_transient( $key );
 
-        if ( $hits >= $max ) {
+        // First request in the window — start a fresh fixed window.
+        if ( false === $data || ! is_array( $data ) ) {
+            set_transient( $key, array( 'count' => 1, 'start' => time() ), $window );
+            return true;
+        }
+
+        $count = (int) ( isset( $data['count'] ) ? $data['count'] : 0 );
+        if ( $count >= $max ) {
             return false;
         }
 
-        set_transient( $key, $hits + 1, $window );
+        // Preserve the original window expiry instead of sliding the TTL forward.
+        $start     = (int) ( isset( $data['start'] ) ? $data['start'] : time() );
+        $remaining = max( 1, $window - ( time() - $start ) );
+        set_transient( $key, array( 'count' => $count + 1, 'start' => $start ), $remaining );
 
         return true;
     }

--- a/src/blocks/QuickSearch/templates/search-results.php
+++ b/src/blocks/QuickSearch/templates/search-results.php
@@ -41,15 +41,15 @@ $result_image_type = $result_image_type ?? 'icon';
                 $doc_type_color = $modal_styles['articleLabelColor'] ?? '#8B5CF6';
             }
 
-            // Get document title
-            $title = is_array( $doc['title'] ) ? $doc['title']['rendered'] : $doc['title'];
+            // Get document title (escaped for HTML — only the <mark> wrapper below is markup).
+            $title = esc_html( is_array( $doc['title'] ) ? $doc['title']['rendered'] : $doc['title'] );
             $permalink = $doc['permalink'] ?? '#';
 
             // Highlight search terms in title
             $highlighted_title = $title;
             if ( ! empty( $query ) && strlen( $query ) >= 2 ) {
                 $highlighted_title = preg_replace(
-                    '/(' . preg_quote( $query, '/' ) . ')/i',
+                    '/(' . preg_quote( esc_html( $query ), '/' ) . ')/i',
                     '<mark class="bg-yellow-200 px-1 rounded">$1</mark>',
                     $title
                 );

--- a/src/blocks/QuickSearch/templates/search-results.php
+++ b/src/blocks/QuickSearch/templates/search-results.php
@@ -41,18 +41,28 @@ $result_image_type = $result_image_type ?? 'icon';
                 $doc_type_color = $modal_styles['articleLabelColor'] ?? '#8B5CF6';
             }
 
-            // Get document title (escaped for HTML — only the <mark> wrapper below is markup).
-            $title = esc_html( is_array( $doc['title'] ) ? $doc['title']['rendered'] : $doc['title'] );
+            // Keep the raw title for matching; escape at output boundaries only.
+            $title = is_array( $doc['title'] ) ? $doc['title']['rendered'] : $doc['title'];
             $permalink = $doc['permalink'] ?? '#';
 
-            // Highlight search terms in title
-            $highlighted_title = $title;
+            // Highlight search terms in title. Match against the raw title so we
+            // never match HTML entity names, then escape every fragment and wrap
+            // only the matched pieces in the trusted <mark> markup.
+            $highlighted_title = esc_html( $title );
             if ( ! empty( $query ) && strlen( $query ) >= 2 ) {
-                $highlighted_title = preg_replace(
-                    '/(' . preg_quote( esc_html( $query ), '/' ) . ')/i',
-                    '<mark class="bg-yellow-200 px-1 rounded">$1</mark>',
-                    $title
+                $parts = preg_split(
+                    '/(' . preg_quote( $query, '/' ) . ')/i',
+                    $title,
+                    -1,
+                    PREG_SPLIT_DELIM_CAPTURE
                 );
+                $highlighted_title = '';
+                foreach ( $parts as $i => $part ) {
+                    // Odd indices are the captured (matched) delimiters.
+                    $highlighted_title .= ( $i % 2 )
+                        ? '<mark class="bg-yellow-200 px-1 rounded">' . esc_html( $part ) . '</mark>'
+                        : esc_html( $part );
+                }
             }
             ?>
 


### PR DESCRIPTION
**Audit tracker:** weDevsOfficial/wedocs-pro#349
**Fixes (audit issues, tracked on the pro repo):** weDevsOfficial/wedocs-pro#344, #345, #346, #347, #348

---

## Summary

Security hardening for weDocs Free (2.3.1). One bundled PR covering the five findings from the manual audit (tracked in `weDevsOfficial/wedocs-pro#349`). All fixes are **backward-compatible** — the public "Generate AI Summary" button and QuickSearch keep working; only anonymous access to unpublished content, cost abuse, and unescaped output are closed.

## Fixes

| Finding | Change | File |
|--------|--------|------|
| Refs weDevsOfficial/wedocs-pro#344 — unauth AI-summary generate (cost abuse + draft leak) | `__return_true` → `generate_summary_permissions_check` (published-only for anon, `edit_docs` bypass) + per-IP rate limit + `wp_kses_post` on save | `includes/API/API.php` |
| Refs weDevsOfficial/wedocs-pro#345 — unauth draft/pending disclosure | `wedocs_get_docs` returns unpublished statuses only to `edit_docs` users | `includes/Ajax.php` |
| Refs weDevsOfficial/wedocs-pro#346 — stored XSS via doc title in QuickSearch | escape title before `<mark>` highlight | `src/blocks/QuickSearch/templates/search-results.php` |
| Refs weDevsOfficial/wedocs-pro#347 — feedback meta on arbitrary post | reject non-`docs` post IDs before `update_post_meta` | `includes/Ajax.php` |
| Refs weDevsOfficial/wedocs-pro#348 — contributor `user_login` enumeration | return `display_name` | `includes/API/API.php` |

Adds `wedocs_rate_limit_ok()` (per-IP transient limiter) in `includes/functions.php`.

## Compatibility
Callers traced in `src/`/`assets/build/` first: the AI-summary button and QuickSearch are public-by-design and stay public (hardened with validation + rate-limit + escaping); `get_docs`/feedback are unchanged for legitimate use. No frontend build change required — `assets/build/**` is CI-generated from `src/**`.

## Testing
`php -l` clean on all changed PHP. Manual: anon generate on a published doc still returns a summary; anon generate on a draft → 403; QuickSearch highlights an HTML-bearing title escaped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access**
  * Added permission checks and rate limits for AI summary generation.
  * Restricted documentation visibility based on editing permissions.
  * Sanitized generated summaries before saving.
  * Validated feedback submissions against documentation content.

* **Improvements**
  * Contributor listings now show display names.
  * Quick Search highlights results safely without exposing unescaped content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->