### PR TITLE
fix: remove duplicated JSX breaking the Dashboard build

### DIFF
--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -247,8 +247,6 @@ const Dashboard = () => {
                           >
                             <ArrowTopRightOnSquareIcon className="h-4 w-4" aria-hidden="true" />
                           </a>
-                            <ArrowTopRightOnSquareIcon className="h-4 w-4" aria-hidden="true" />
-                          </a>
                         </span>
                       </td>
                     </tr>


### PR DESCRIPTION
## Problem

`develop` does not build. The Dashboard merge (#327) left a duplicated closing `</a>` plus a stray `ArrowTopRightOnSquareIcon` in the *Recently Updated* table:

```
ERROR in ./src/components/Dashboard/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
> 251 |                           </a>
```

Since `assets/build/` is CI-generated and the 10up deploy ships the built working tree, a failing `npm run build` blocks the wp.org release entirely.

## Fix

Remove the two stray lines in `src/components/Dashboard/index.js`.

## Verification

`npm run build` — webpack compiles clean (warnings only, no errors).

Blocks the 2.4.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the icon display for “View” links in the “Recently Updated” table.
  * Improved markup formatting to ensure the link renders cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->