### PR TITLE
improve: match Premium page to Figma design and update pricing

### DIFF
--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -31,6 +31,7 @@ class Menu {
         add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
         add_action( 'admin_menu', array( $this, 'add_admin_submenu' ) );
         add_action( 'admin_head', array( $this, 'cleanup_admin_notices' ), 1 );
+        add_action( 'admin_head', array( $this, 'premium_menu_styles' ) );
     }
 
     /**
@@ -97,7 +98,7 @@ class Menu {
 
         if ( ! wedocs_is_pro_active() ) {
             $all_submenus[] = array(
-                __( 'Premium', 'wedocs' ),
+                $this->get_premium_menu_title(),
                 $this->capability,
                 $base . '#/premium',
             );
@@ -112,6 +113,83 @@ class Menu {
             $submenu['wedocs'],
             ...$all_submenus
         );
+    }
+
+    /**
+     * Build the Premium submenu title with its crown icon.
+     *
+     * WordPress prints submenu titles unescaped, so markup is allowed here. The
+     * crown is inlined rather than enqueued so it costs no extra request, and the
+     * glow itself is handled in CSS — see premium_menu_styles().
+     *
+     * @since 2.4.0
+     *
+     * @return string
+     */
+    public function get_premium_menu_title() {
+        $crown = '<svg class="wedocs-premium-menu__crown" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 16L3 6l5.5 4L12 4l3.5 6L21 6l-2 10H5zm14 3a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1v-1h14v1z"/></svg>';
+
+        return '<span class="wedocs-premium-menu">' . esc_html__( 'Premium', 'wedocs' ) . $crown . '</span>';
+    }
+
+    /**
+     * Print the glow styles for the Premium submenu item.
+     *
+     * Lives in admin_head because the admin menu renders on every screen, while
+     * the plugin stylesheet is only enqueued on weDocs pages.
+     *
+     * @since 2.4.0
+     *
+     * @return void
+     */
+    public function premium_menu_styles() {
+        if ( wedocs_is_pro_active() ) {
+            return;
+        }
+        ?>
+        <style id="wedocs-premium-menu-style">
+            #adminmenu .wedocs-premium-menu {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                font-weight: 600;
+                color: #ffb900;
+            }
+
+            #adminmenu .wedocs-premium-menu__crown {
+                width: 14px;
+                height: 14px;
+                flex-shrink: 0;
+                fill: currentColor;
+                animation: wedocs-premium-glow 2.4s ease-in-out infinite;
+            }
+
+            #adminmenu a:hover .wedocs-premium-menu,
+            #adminmenu a:focus .wedocs-premium-menu,
+            #adminmenu .current .wedocs-premium-menu {
+                color: #ffc83d;
+            }
+
+            @keyframes wedocs-premium-glow {
+                0%, 100% {
+                    filter: drop-shadow( 0 0 0 rgba( 255, 185, 0, 0 ) );
+                    transform: scale( 1 );
+                }
+
+                50% {
+                    filter: drop-shadow( 0 0 5px rgba( 255, 185, 0, .9 ) );
+                    transform: scale( 1.12 );
+                }
+            }
+
+            @media ( prefers-reduced-motion: reduce ) {
+                #adminmenu .wedocs-premium-menu__crown {
+                    animation: none;
+                    filter: drop-shadow( 0 0 3px rgba( 255, 185, 0, .7 ) );
+                }
+            }
+        </style>
+        <?php
     }
 
     /**

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -27,6 +27,25 @@ html.wp-toolbar {
     margin-right: 0;
 }
 
+/*
+ * The premium upgrade page is a full-bleed design (see Figma weDocs-Pro-Design):
+ * its bands run edge to edge, so the admin chrome padding has to go. Scoped to a
+ * body class the Premium component toggles on mount, so every other weDocs admin
+ * screen keeps the 25px gutter above. !important is required to beat the
+ * max-width:782px rule below, which is itself !important.
+ */
+body.wedocs-premium-fullwidth #wpcontent {
+    padding: 0 !important;
+}
+
+body.wedocs-premium-fullwidth #wpbody-content {
+    padding-bottom: 0;
+}
+
+body.wedocs-premium-fullwidth #wpbody-content > .wrap {
+    margin: 0;
+}
+
 #adminmenu .wp-menu-image img {
     margin: 0 auto;
 }

--- a/src/components/Premium/index.js
+++ b/src/components/Premium/index.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 import heroIllustration from '../../assets/img/premium/hero-illustration.png';
 import videoThumbnail from '../../assets/img/premium/video-thumbnail.png';
@@ -25,6 +25,9 @@ import iconTranslation from '../../assets/img/premium/icon-translation.svg';
 const PRICING_URL =
   'https://wedocs.co/pricing/?utm_source=wp-admin&utm_medium=premium-page&utm_campaign=upgrade';
 const COUPON_CODE = 'LiteUpgrade25';
+const VIDEO_ID = 'UgXtmkgAEGI';
+const VIDEO_URL = `https://www.youtube.com/watch?v=${ VIDEO_ID }`;
+const VIDEO_EMBED_URL = `https://www.youtube-nocookie.com/embed/${ VIDEO_ID }?autoplay=1&rel=0`;
 
 const ArrowRightIcon = ( { className = 'w-5 h-5' } ) => (
   <svg
@@ -41,20 +44,14 @@ const ArrowRightIcon = ( { className = 'w-5 h-5' } ) => (
   </svg>
 );
 
-const CopyIcon = ( { className = 'w-5 h-5' } ) => (
+const PlayIcon = () => (
   <svg
-    className={ className }
+    className="w-7 h-7 text-white"
     viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
+    fill="currentColor"
     aria-hidden="true"
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-    />
+    <path d="M8 5v14l11-7z" />
   </svg>
 );
 
@@ -224,7 +221,9 @@ const pricingPlans = [
     badge: null,
     description: __( 'Everything you need for professional docs on a single site', 'wedocs' ),
     annual: 39,
-    lifetime: 125,
+    lifetime: 119,
+    lifetimeRegular: 125,
+    lifetimeDiscount: 5,
     sites: __( '1 Site', 'wedocs' ),
     highlighted: false,
   },
@@ -233,7 +232,9 @@ const pricingPlans = [
     badge: null,
     description: __( 'Do more with weDocs using powerful advanced features', 'wedocs' ),
     annual: 59,
-    lifetime: 165,
+    lifetime: 149,
+    lifetimeRegular: 165,
+    lifetimeDiscount: 10,
     sites: __( '5 Sites', 'wedocs' ),
     highlighted: false,
   },
@@ -242,7 +243,9 @@ const pricingPlans = [
     badge: { label: __( 'Most Popular', 'wedocs' ), className: 'bg-[#FFE2B4]' },
     description: __( 'The ultimate documentation toolkit for growing teams', 'wedocs' ),
     annual: 79,
-    lifetime: 235,
+    lifetime: 199,
+    lifetimeRegular: 235,
+    lifetimeDiscount: 15,
     sites: __( '10 Sites', 'wedocs' ),
     highlighted: true,
   },
@@ -251,42 +254,28 @@ const pricingPlans = [
     badge: { label: __( 'Best Valued', 'wedocs' ), className: 'bg-[#88FFB3]' },
     description: __( 'Reach greater heights with docs across all client sites', 'wedocs' ),
     annual: 149,
-    lifetime: 312,
+    lifetime: 249,
+    lifetimeRegular: 312,
+    lifetimeDiscount: 20,
     sites: __( 'Unlimited Sites', 'wedocs' ),
     highlighted: false,
   },
 ];
 
-const CouponButton = ( { dark = true } ) => {
-  const [ copied, setCopied ] = useState( false );
-
-  const copyCoupon = () => {
-    window.navigator.clipboard?.writeText( COUPON_CODE );
-    setCopied( true );
-    setTimeout( () => setCopied( false ), 2000 );
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={ copyCoupon }
-      className={ `inline-flex items-center gap-3 rounded-md border pl-[17px] pr-[15px] py-[9px] text-base font-medium transition-colors cursor-pointer ${
-        dark
-          ? 'bg-transparent border-[#3C434A] text-[#A7AAAD] hover:text-white'
-          : 'bg-white border-gray-300 text-gray-600'
-      }` }
-    >
-      { copied
-        ? __( 'Copied!', 'wedocs' )
-        : sprintf(
-          /* translators: %s: coupon code */
-          __( 'Coupon: %s', 'wedocs' ),
-          COUPON_CODE
-        ) }
-      <CopyIcon />
-    </button>
-  );
-};
+const CouponBadge = ( { dark = true } ) => (
+  <span
+    className={ `inline-flex items-center gap-2 rounded-md border pl-[17px] pr-[15px] py-[9px] text-base font-medium ${
+      dark
+        ? 'bg-transparent border-[#3C434A] text-[#A7AAAD]'
+        : 'bg-white border-gray-300 text-gray-600'
+    }` }
+  >
+    { __( 'Coupon:', 'wedocs' ) }
+    <strong className={ dark ? 'text-white' : 'text-[#23282D]' }>
+      { COUPON_CODE }
+    </strong>
+  </span>
+);
 
 const HeroSection = () => (
   <section className="relative overflow-hidden rounded-[20px] bg-[#000823]">
@@ -312,14 +301,14 @@ const HeroSection = () => (
         <PrimaryLinkButton href={ PRICING_URL }>
           { __( 'Upgrade to Pro', 'wedocs' ) }
         </PrimaryLinkButton>
-        <CouponButton />
+        <CouponBadge />
       </div>
     </div>
     <div className="absolute top-8 right-0 hidden xl:block w-[426px]">
       <img
         src={ heroIllustration }
         alt=""
-        className="w-full max-w-full h-auto"
+        className="w-full max-w-full h-auto border-0"
       />
       <span className="absolute left-1/2 -translate-x-1/2 bottom-4 rounded-full bg-[#000D37] px-8 py-2.5 text-2xl font-bold text-white whitespace-nowrap">
         { __( 'Up to 25% Off', 'wedocs' ) }
@@ -405,12 +394,16 @@ const FeatureCardsSection = () => (
             className="flex min-h-[214px] flex-col gap-5 rounded-[20px] border border-gray-200 bg-white p-5"
           >
             <span className="relative self-start w-[35px]">
-              <img src={ card.icon } alt="" className="block h-9 w-auto" />
+              <img
+                src={ card.icon }
+                alt=""
+                className="block h-9 w-auto border-0"
+              />
               { card.iconOverlay && (
                 <img
                   src={ card.iconOverlay }
                   alt=""
-                  className="absolute -right-2 -top-1 h-4 w-auto"
+                  className="absolute -right-2 -top-1 h-4 w-auto border-0"
                 />
               ) }
             </span>
@@ -432,36 +425,58 @@ const FeatureCardsSection = () => (
   </section>
 );
 
-const DokanSection = () => (
-  <section className="mx-auto flex w-full max-w-[1000px] flex-col items-center gap-10 px-8 xl:px-0">
-    <div className="flex max-w-[581px] flex-col items-center gap-4 text-center">
-      <h2 className="text-3xl font-bold text-gray-800 m-0 p-0">
-        { __( 'Dokan Support for weDocs', 'wedocs' ) }
-      </h2>
-      <p className="m-0 text-sm text-gray-500">
-        { __(
-          'This feature lets marketplace owners create vendor-specific documentation to simplify onboarding, store management, policies, payments, and other resources.',
-          'wedocs'
+const DokanSection = () => {
+  const [ playing, setPlaying ] = useState( false );
+  const videoTitle = __( 'How to mark a doc as vendor docs', 'wedocs' );
+
+  return (
+    <section className="mx-auto flex w-full max-w-[1000px] flex-col items-center gap-11 px-8 xl:px-0">
+      <div className="flex max-w-[581px] flex-col items-center gap-4 text-center">
+        <h2 className="text-3xl font-bold text-gray-800 m-0 p-0">
+          { __( 'Dokan Support for weDocs', 'wedocs' ) }
+        </h2>
+        <p className="m-0 text-sm text-gray-500">
+          { __(
+            'This feature lets marketplace owners create vendor-specific documentation to simplify onboarding, store management, policies, payments, and other resources.',
+            'wedocs'
+          ) }
+        </p>
+      </div>
+      <div className="relative w-full overflow-hidden rounded-[20px] aspect-video bg-[#0A101A]">
+        { playing ? (
+          <iframe
+            src={ VIDEO_EMBED_URL }
+            title={ videoTitle }
+            className="absolute inset-0 h-full w-full border-0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={ () => setPlaying( true ) }
+            aria-label={ videoTitle }
+            className="group absolute inset-0 h-full w-full cursor-pointer border-0 bg-transparent p-0"
+          >
+            <img
+              src={ videoThumbnail }
+              alt={ videoTitle }
+              className="block h-full w-full border-0 object-cover"
+            />
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="flex h-[68px] w-[96px] items-center justify-center rounded-[14px] bg-black/60 transition-colors group-hover:bg-[#FF0000]">
+                <PlayIcon />
+              </span>
+            </span>
+          </button>
         ) }
-      </p>
-    </div>
-    <a
-      href={ PRICING_URL }
-      target="_blank"
-      rel="noopener noreferrer"
-      className="block w-full overflow-hidden rounded-[20px]"
-    >
-      <img
-        src={ videoThumbnail }
-        alt={ __( 'How to mark a doc as vendor docs', 'wedocs' ) }
-        className="block w-full max-w-full h-auto"
-      />
-    </a>
-    <PrimaryLinkButton href={ PRICING_URL }>
-      { __( 'View Details', 'wedocs' ) }
-    </PrimaryLinkButton>
-  </section>
-);
+      </div>
+      <PrimaryLinkButton href={ VIDEO_URL }>
+        { __( 'Watch on YouTube', 'wedocs' ) }
+      </PrimaryLinkButton>
+    </section>
+  );
+};
 
 const BrandsSection = () => (
   <section className="mx-auto flex w-full max-w-[1200px] flex-col items-center gap-14 px-8 xl:px-0">
@@ -474,7 +489,7 @@ const BrandsSection = () => (
         'Dokan, WP User Frontend, WP ERP, WP Project Manager, FlyWP, WP Hive, weMail, Appsero, weDocs, wePOS, and InboxWP logos',
         'wedocs'
       ) }
-      className="w-full max-w-[1013px] h-auto"
+      className="w-full max-w-[1013px] h-auto border-0"
     />
   </section>
 );
@@ -551,12 +566,30 @@ const PricingSection = () => {
                 { plan.description }
               </p>
             </div>
-            <p className="m-0 text-4xl font-bold text-[#101828]">
-              ${ isAnnual ? plan.annual : plan.lifetime }
-              <span className="text-base font-normal text-[#6A7282]">
-                { isAnnual ? __( '/y', 'wedocs' ) : __( '/lifetime', 'wedocs' ) }
-              </span>
-            </p>
+            <div className="flex flex-col gap-1.5">
+              <p className="m-0 text-4xl font-bold text-[#101828]">
+                ${ isAnnual ? plan.annual : plan.lifetime }
+                <span className="text-base font-normal text-[#6A7282]">
+                  { isAnnual
+                    ? __( '/y', 'wedocs' )
+                    : __( '/lifetime', 'wedocs' ) }
+                </span>
+              </p>
+              { ! isAnnual && (
+                <p className="m-0 flex items-center gap-2 text-sm text-[#6A7282]">
+                  <span className="line-through">
+                    ${ plan.lifetimeRegular }
+                  </span>
+                  <span className="rounded-[20px] bg-[#ECFDF5] px-2 py-0.5 text-xs font-semibold text-[#047857]">
+                    { sprintf(
+                      /* translators: %s: discount percentage, e.g. 15% */
+                      __( 'Save %s', 'wedocs' ),
+                      `${ plan.lifetimeDiscount }%`
+                    ) }
+                  </span>
+                </p>
+              ) }
+            </div>
             <a
               href={ PRICING_URL }
               target="_blank"
@@ -587,6 +620,32 @@ const PricingSection = () => {
             </ul>
           </div>
         ) ) }
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-3 rounded-2xl border border-[#E4E4E4] bg-white px-8 py-6 text-center sm:flex-row sm:justify-center sm:gap-4 sm:text-left">
+        <span className="relative w-[35px] shrink-0">
+          <img
+            src={ iconAiChatbot }
+            alt=""
+            className="block h-9 w-auto border-0"
+          />
+          <img
+            src={ iconAiSparkle }
+            alt=""
+            className="absolute -right-2 -top-1 h-4 w-auto border-0"
+          />
+        </span>
+        <p className="m-0 text-sm text-[#4A5565]">
+          <strong className="text-[#101828]">
+            { __( 'AI Chatbot Add-on', 'wedocs' ) }
+          </strong>{ ' ' }
+          { __( 'is available on any plan for', 'wedocs' ) }{ ' ' }
+          <strong className="text-[#101828]">
+            { __( '$7.99/month', 'wedocs' ) }
+          </strong>
+          { '. ' }
+          { __( 'Not available as a lifetime purchase.', 'wedocs' ) }
+        </p>
       </div>
     </section>
   );
@@ -624,7 +683,7 @@ const RefundSection = () => (
       <img
         src={ refundBadge }
         alt={ __( '14-day money back guarantee', 'wedocs' ) }
-        className="h-[158px] w-[158px] shrink-0"
+        className="h-[158px] w-[158px] shrink-0 border-0"
       />
     </div>
   </section>
@@ -635,7 +694,7 @@ const FinalCtaSection = () => (
     <img
       src={ heroIllustration }
       alt=""
-      className="pointer-events-none absolute -right-6 -bottom-10 w-[235px] max-w-none opacity-30"
+      className="pointer-events-none absolute -right-6 -bottom-10 w-[235px] max-w-none opacity-30 border-0"
     />
     <div className="relative z-10 flex flex-col items-start gap-6 p-10 lg:flex-row lg:items-center lg:justify-between">
       <div className="flex max-w-[458px] flex-col gap-4">
@@ -659,21 +718,35 @@ const FinalCtaSection = () => (
   </section>
 );
 
-const Premium = () => (
-  <div className="wedocs-premium-page -mx-2.5 bg-[#F5F5F5] pb-[72px]">
-    <div className="mx-auto flex max-w-[1216px] flex-col gap-[72px] px-8 pt-[72px] xl:px-0">
-      <HeroSection />
-      <ComparisonSection />
+const Premium = () => {
+  // Full-bleed design: strip the admin chrome padding while this page is mounted.
+  useEffect( () => {
+    document.body.classList.add( 'wedocs-premium-fullwidth' );
+
+    return () => document.body.classList.remove( 'wedocs-premium-fullwidth' );
+  }, [] );
+
+  return (
+    <div className="wedocs-premium-page bg-[#F5F5F5] pb-[72px]">
+      <div className="mx-auto flex max-w-[1216px] flex-col gap-[72px] px-8 pt-[72px] xl:px-0">
+        <HeroSection />
+        <ComparisonSection />
+      </div>
+      <div className="mt-[72px] flex flex-col">
+        <FeatureCardsSection />
+        { /* Dokan + brands sit on a white band in the design, not on the page gray. */ }
+        <div className="flex flex-col gap-[72px] bg-white py-[72px]">
+          <DokanSection />
+          <BrandsSection />
+        </div>
+        <div className="flex flex-col gap-[72px] pt-[72px]">
+          <PricingSection />
+          <RefundSection />
+          <FinalCtaSection />
+        </div>
+      </div>
     </div>
-    <div className="mt-[72px] flex flex-col gap-[72px]">
-      <FeatureCardsSection />
-      <DokanSection />
-      <BrandsSection />
-      <PricingSection />
-      <RefundSection />
-      <FinalCtaSection />
-    </div>
-  </div>
-);
+  );
+};
 
 export default Premium;


### PR DESCRIPTION
Syncs the Premium upgrade page with the [weDocs Pro Figma design](https://www.figma.com/design/OV7RlDvKmFPCXyGI9pyipC/weDocs-Pro-Design?node-id=5239-11383) and refreshes plan pricing.

### Background bands
The design uses three bands, not one. Dokan + brands sit on **white**; the page rendered them on `#F5F5F5`. Both assets bake white into their background/rounded corners, so the mismatch showed up as a white box with hard edges — the reported "border".

| Design y | Band | Hex |
|---|---|---|
| 0–983 | Hero + Comparison | `#F5F5F5` |
| 0–983 | AI Features | `#D2D6E4` |
| 983–2123 | **Dokan + Brands** | `#FFFFFF` ← fixed |
| 2123–3840 | Pricing → CTA | `#F5F5F5` |

### Pricing
| Plan | Sites | Yearly | Lifetime |
|---|---|---|---|
| Starter | 1 | $39 | ~~$125~~ $119 (5%) |
| Professional | 5 | $59 | ~~$165~~ $149 (10%) |
| Business | 10 | $79 | ~~$235~~ $199 (15%) |
| Agency | Unlimited | $149 | ~~$312~~ $249 (20%) |

Plus AI Chatbot add-on at $7.99/month (not available lifetime).

### Also
- Dokan cover image (previously just a link to pricing) → click-to-play YouTube embed via `youtube-nocookie.com`, no request until play.
- Coupon clipboard-copy button → static badge.
- `#wpcontent` padding suppressed while mounted, scoped to a body class so other weDocs screens keep their gutter.
- Premium submenu gets a glowing crown; skipped when Pro is active, static under `prefers-reduced-motion`.

### Testing
`npm run build` compiles clean. No new eslint errors (6 pre-existing remain). `php -l` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned Premium menu item with crown styling and hover effects.
  - Added a full-width layout for the Premium administration screen.
  - Added updated pricing displays, lifetime plan offers, and an AI Chatbot add-on card.
  - Added an embedded YouTube demo that opens directly from the feature card.
  - Added a static coupon badge and refreshed Premium page visuals.

- **Style**
  - Refined spacing, borders, illustrations, and responsive Premium page layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->