### PR TITLE
Improve footer responsiveness, widen breakpoint

### DIFF
--- a/src/assets/less/responsive.less
+++ b/src/assets/less/responsive.less
@@ -63,13 +63,22 @@
     }
 
     footer.entry-footer.wedocs-entry-footer {
+        flex-direction: column;
+        align-items: stretch;
+
         .help-content {
+            width: 100%;
+            margin-right: 0;
+            margin-bottom: 16px;
+
             .wedocs-help-link {
                 font-size: 13px;
             }
         }
 
         .feedback-content {
+            width: 100%;
+
             .wedocs-feedback-wrap {
                 line-height: 56px;
 
@@ -81,7 +90,7 @@
     }
 }
 
-@media screen and (max-width: 425px) {
+@media screen and (max-width: 480px) {
 
     .wedocs-hide-mobile {
         display: none;


### PR DESCRIPTION
Fixes #339

Make the weDocs entry footer stack on small screens by switching `footer.entry-footer.wedocs-entry-footer` to column layout and stretching children. Ensure `.help-content` and `.feedback-content` use full width, remove right margin, and add bottom spacing for better stacking. Increase mobile breakpoint from `max-width: 425px` to `max-width: 480px` so mobile-specific rules apply to modern devices (390–430 CSS px wide).

### Verified
Tested with Playwright at 390px, 430px, 768px, and 1280px viewports:
- 390/430px: footer stacks in a column, help box hidden, feedback box full width, zero horizontal overflow
- 768px: help + feedback stacked full width
- 1280px: desktop row layout unchanged (40/60 side by side)

Reported on wp.org: https://wordpress.org/support/topic/footer-alignment-12/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of footer, help, and feedback sections on small screens.
  * Adjusted spacing and alignment for better readability on mobile devices.
  * Expanded responsive styling to support screens up to 480px wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->